### PR TITLE
fix(api): add authentication to /reserve and /grab endpoints

### DIFF
--- a/api/coupon_reservation.go
+++ b/api/coupon_reservation.go
@@ -116,7 +116,7 @@ func (s *Server) createCouponReservation(ctx *gin.Context) {
 	userIDStr := strconv.FormatInt(int64(req.UserID), 10)
 
 	if s.bloomFilterForReserve.TestString(userIDStr) { // Check if the user has already reserved
-		ctx.JSON(http.StatusBadRequest, errorResponse(errors.New("User already reserved")))
+		ctx.JSON(http.StatusBadRequest, errorResponse(errors.New("user already reserved")))
 		return
 	}
 	couponReservation, err := s.store.CreateCouponReservation(ctx, req.UserID)

--- a/api/coupon_reservation.go
+++ b/api/coupon_reservation.go
@@ -109,35 +109,23 @@ func (s *Server) createCouponReservation(ctx *gin.Context) {
 	}
 
 	// Authorization check: ensure user can only create reservation for themselves
-	authUserID, err := getUserIDFromContext(ctx)
-	if err != nil {
-		if errors.Is(err, ErrUnauthorized) {
-			ctx.JSON(http.StatusUnauthorized, errorResponse(err))
-		} else {
-			ctx.JSON(http.StatusInternalServerError, errorResponse(err))
-		}
+	if err := checkUserAuthorization(ctx, req.UserID); err != nil {
 		return
 	}
 
-	if authUserID != req.UserID {
-		ctx.JSON(http.StatusForbidden, errorResponse(errors.New("access denied: cannot create reservation for another user")))
-		return
-	}
+	userIDStr := strconv.FormatInt(int64(req.UserID), 10)
 
-	UserID := int(req.UserID) // Convert int32 to int
-	userIdStr := strconv.Itoa(UserID)
-
-	if s.bloomFilterForReserve.TestString(userIdStr) { // Check if the user has already reserved
+	if s.bloomFilterForReserve.TestString(userIDStr) { // Check if the user has already reserved
 		ctx.JSON(http.StatusBadRequest, errorResponse(errors.New("User already reserved")))
 		return
 	}
-	couponReservation, err := s.store.CreateCouponReservation(ctx, int32(UserID))
+	couponReservation, err := s.store.CreateCouponReservation(ctx, req.UserID)
 
 	if err != nil {
 		ctx.JSON(http.StatusInternalServerError, errorResponse(err))
 		return
 	}
-	s.bloomFilterForReserve.AddString(userIdStr) // Add the user to the reservation Bloom filter
+	s.bloomFilterForReserve.AddString(userIDStr) // Add the user to the reservation Bloom filter
 	ctx.JSON(http.StatusOK, couponReservation)
 }
 

--- a/api/coupon_reservation.go
+++ b/api/coupon_reservation.go
@@ -82,7 +82,7 @@ func (s *Server) getCouponReservation(ctx *gin.Context) {
 	}
 
 	if userID != req.UserID {
-		ctx.JSON(http.StatusForbidden, errorResponse(errors.New("access denied")))
+		ctx.JSON(http.StatusForbidden, errorResponse(ErrAccessDenied))
 		return
 	}
 

--- a/api/coupon_reservation.go
+++ b/api/coupon_reservation.go
@@ -108,6 +108,22 @@ func (s *Server) createCouponReservation(ctx *gin.Context) {
 		return
 	}
 
+	// Authorization check: ensure user can only create reservation for themselves
+	authUserID, err := getUserIDFromContext(ctx)
+	if err != nil {
+		if errors.Is(err, ErrUnauthorized) {
+			ctx.JSON(http.StatusUnauthorized, errorResponse(err))
+		} else {
+			ctx.JSON(http.StatusInternalServerError, errorResponse(err))
+		}
+		return
+	}
+
+	if authUserID != req.UserID {
+		ctx.JSON(http.StatusForbidden, errorResponse(errors.New("access denied: cannot create reservation for another user")))
+		return
+	}
+
 	UserID := int(req.UserID) // Convert int32 to int
 	userIdStr := strconv.Itoa(UserID)
 

--- a/api/grab.go
+++ b/api/grab.go
@@ -104,6 +104,22 @@ func (s *Server) handleGrabRequest(ctx *gin.Context) {
 		return
 	}
 
+	// Authorization check: ensure user can only grab for themselves
+	authUserID, err := getUserIDFromContext(ctx)
+	if err != nil {
+		if errors.Is(err, ErrUnauthorized) {
+			ctx.JSON(http.StatusUnauthorized, errorResponse(err))
+		} else {
+			ctx.JSON(http.StatusInternalServerError, errorResponse(err))
+		}
+		return
+	}
+
+	if int(authUserID) != req.UserID {
+		ctx.JSON(http.StatusForbidden, errorResponse(errors.New("access denied: cannot grab for another user")))
+		return
+	}
+
 	userIDStr := strconv.Itoa(req.UserID)
 	if s.bloomFilterForGrab.TestString(userIDStr) { // Check if the user has already grabbed
 		ctx.JSON(http.StatusBadRequest, errorResponse(errors.New("User already grabbed")))

--- a/api/grab.go
+++ b/api/grab.go
@@ -111,7 +111,7 @@ func (s *Server) handleGrabRequest(ctx *gin.Context) {
 
 	userIDStr := strconv.FormatInt(int64(req.UserID), 10)
 	if s.bloomFilterForGrab.TestString(userIDStr) { // Check if the user has already grabbed
-		ctx.JSON(http.StatusBadRequest, errorResponse(errors.New("User already grabbed")))
+		ctx.JSON(http.StatusBadRequest, errorResponse(errors.New("user already grabbed")))
 		return
 	}
 

--- a/api/grab.go
+++ b/api/grab.go
@@ -18,7 +18,7 @@ import (
 )
 
 type getGrabRequest struct {
-	UserID int `json:"user_id" binding:"required,min=1"` // The user ID for the grab request
+	UserID int32 `json:"user_id" binding:"required,min=1"` // The user ID for the grab request
 }
 
 func selectWinnersSimple(reservedUsers map[int]int, numWinners int) []int {
@@ -105,28 +105,17 @@ func (s *Server) handleGrabRequest(ctx *gin.Context) {
 	}
 
 	// Authorization check: ensure user can only grab for themselves
-	authUserID, err := getUserIDFromContext(ctx)
-	if err != nil {
-		if errors.Is(err, ErrUnauthorized) {
-			ctx.JSON(http.StatusUnauthorized, errorResponse(err))
-		} else {
-			ctx.JSON(http.StatusInternalServerError, errorResponse(err))
-		}
+	if err := checkUserAuthorization(ctx, req.UserID); err != nil {
 		return
 	}
 
-	if int(authUserID) != req.UserID {
-		ctx.JSON(http.StatusForbidden, errorResponse(errors.New("access denied: cannot grab for another user")))
-		return
-	}
-
-	userIDStr := strconv.Itoa(req.UserID)
+	userIDStr := strconv.FormatInt(int64(req.UserID), 10)
 	if s.bloomFilterForGrab.TestString(userIDStr) { // Check if the user has already grabbed
 		ctx.JSON(http.StatusBadRequest, errorResponse(errors.New("User already grabbed")))
 		return
 	}
 
-	reservation, err := s.store.Queries.GetCouponReservation(ctx, int32(req.UserID))
+	reservation, err := s.store.Queries.GetCouponReservation(ctx, req.UserID)
 	if err != nil {
 		ctx.JSON(http.StatusInternalServerError, errorResponse(err))
 		return

--- a/api/grab_test.go
+++ b/api/grab_test.go
@@ -16,14 +16,14 @@ func init() {
 }
 
 // setupAuthTimeRestrictedTestRouter creates a test router with auth middleware
-// that mimics the authorization logic of handleGrabRequest and createCouponReservation.
+// that uses the same authorization logic as handleGrabRequest and createCouponReservation.
 // Note: We don't include specialTime middleware in tests as it depends on global time config.
 func setupAuthTimeRestrictedTestRouter() *gin.Engine {
 	router := gin.New()
 
 	authenticated := router.Group("/", authMiddleware())
 	{
-		// Simulated /grab handler with auth check
+		// Simulated /grab handler with auth check using helper function
 		authenticated.POST("/grab", func(c *gin.Context) {
 			var req getGrabRequest
 			if err := c.ShouldBindJSON(&req); err != nil {
@@ -31,21 +31,15 @@ func setupAuthTimeRestrictedTestRouter() *gin.Engine {
 				return
 			}
 
-			authUserID, err := getUserIDFromContext(c)
-			if err != nil {
-				c.JSON(http.StatusUnauthorized, errorResponse(err))
+			if err := checkUserAuthorization(c, req.UserID); err != nil {
 				return
 			}
 
-			if int(authUserID) != req.UserID {
-				c.JSON(http.StatusForbidden, gin.H{"error": "access denied: cannot grab for another user"})
-				return
-			}
-
+			authUserID, _ := getUserIDFromContext(c)
 			c.JSON(http.StatusOK, gin.H{"status": "authorized", "user_id": authUserID})
 		})
 
-		// Simulated /reserve handler with auth check
+		// Simulated /reserve handler with auth check using helper function
 		authenticated.POST("/reserve", func(c *gin.Context) {
 			var req createCouponReservationRequest
 			if err := c.ShouldBindJSON(&req); err != nil {
@@ -53,17 +47,11 @@ func setupAuthTimeRestrictedTestRouter() *gin.Engine {
 				return
 			}
 
-			authUserID, err := getUserIDFromContext(c)
-			if err != nil {
-				c.JSON(http.StatusUnauthorized, errorResponse(err))
+			if err := checkUserAuthorization(c, req.UserID); err != nil {
 				return
 			}
 
-			if authUserID != req.UserID {
-				c.JSON(http.StatusForbidden, gin.H{"error": "access denied: cannot create reservation for another user"})
-				return
-			}
-
+			authUserID, _ := getUserIDFromContext(c)
 			c.JSON(http.StatusOK, gin.H{"status": "authorized", "user_id": authUserID})
 		})
 	}

--- a/api/grab_test.go
+++ b/api/grab_test.go
@@ -1,0 +1,278 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func init() {
+	gin.SetMode(gin.TestMode)
+}
+
+// setupAuthTimeRestrictedTestRouter creates a test router with auth middleware
+// that mimics the authorization logic of handleGrabRequest and createCouponReservation.
+// Note: We don't include specialTime middleware in tests as it depends on global time config.
+func setupAuthTimeRestrictedTestRouter() *gin.Engine {
+	router := gin.New()
+
+	authenticated := router.Group("/", authMiddleware())
+	{
+		// Simulated /grab handler with auth check
+		authenticated.POST("/grab", func(c *gin.Context) {
+			var req getGrabRequest
+			if err := c.ShouldBindJSON(&req); err != nil {
+				c.JSON(http.StatusBadRequest, errorResponse(err))
+				return
+			}
+
+			authUserID, err := getUserIDFromContext(c)
+			if err != nil {
+				c.JSON(http.StatusUnauthorized, errorResponse(err))
+				return
+			}
+
+			if int(authUserID) != req.UserID {
+				c.JSON(http.StatusForbidden, gin.H{"error": "access denied: cannot grab for another user"})
+				return
+			}
+
+			c.JSON(http.StatusOK, gin.H{"status": "authorized", "user_id": authUserID})
+		})
+
+		// Simulated /reserve handler with auth check
+		authenticated.POST("/reserve", func(c *gin.Context) {
+			var req createCouponReservationRequest
+			if err := c.ShouldBindJSON(&req); err != nil {
+				c.JSON(http.StatusBadRequest, errorResponse(err))
+				return
+			}
+
+			authUserID, err := getUserIDFromContext(c)
+			if err != nil {
+				c.JSON(http.StatusUnauthorized, errorResponse(err))
+				return
+			}
+
+			if authUserID != req.UserID {
+				c.JSON(http.StatusForbidden, gin.H{"error": "access denied: cannot create reservation for another user"})
+				return
+			}
+
+			c.JSON(http.StatusOK, gin.H{"status": "authorized", "user_id": authUserID})
+		})
+	}
+
+	return router
+}
+
+// TestGrabEndpoint_Authentication tests that the /grab endpoint requires authentication.
+func TestGrabEndpoint_Authentication(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		userIDHeader   string
+		requestBody    map[string]interface{}
+		expectedStatus int
+		expectedError  string
+	}{
+		{
+			name:           "missing auth header returns 401",
+			userIDHeader:   "",
+			requestBody:    map[string]interface{}{"user_id": 1},
+			expectedStatus: http.StatusUnauthorized,
+			expectedError:  "missing X-User-ID header",
+		},
+		{
+			name:           "invalid auth header returns 400",
+			userIDHeader:   "invalid",
+			requestBody:    map[string]interface{}{"user_id": 1},
+			expectedStatus: http.StatusBadRequest,
+			expectedError:  "invalid X-User-ID header",
+		},
+		{
+			name:           "IDOR attempt - grabbing for another user returns 403",
+			userIDHeader:   "1",
+			requestBody:    map[string]interface{}{"user_id": 2},
+			expectedStatus: http.StatusForbidden,
+			expectedError:  "access denied",
+		},
+		{
+			name:           "valid auth - user can grab for themselves",
+			userIDHeader:   "1",
+			requestBody:    map[string]interface{}{"user_id": 1},
+			expectedStatus: http.StatusOK,
+			expectedError:  "",
+		},
+	}
+
+	router := setupAuthTimeRestrictedTestRouter()
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			body, err := json.Marshal(tc.requestBody)
+			require.NoError(t, err)
+
+			req, err := http.NewRequest(http.MethodPost, "/grab", bytes.NewBuffer(body))
+			require.NoError(t, err)
+			req.Header.Set("Content-Type", "application/json")
+
+			if tc.userIDHeader != "" {
+				req.Header.Set("X-User-ID", tc.userIDHeader)
+			}
+
+			recorder := httptest.NewRecorder()
+			router.ServeHTTP(recorder, req)
+
+			require.Equal(t, tc.expectedStatus, recorder.Code)
+			if tc.expectedError != "" {
+				require.Contains(t, recorder.Body.String(), tc.expectedError)
+			}
+		})
+	}
+}
+
+// TestReserveEndpoint_Authentication tests that the /reserve endpoint requires authentication.
+func TestReserveEndpoint_Authentication(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		userIDHeader   string
+		requestBody    map[string]interface{}
+		expectedStatus int
+		expectedError  string
+	}{
+		{
+			name:           "missing auth header returns 401",
+			userIDHeader:   "",
+			requestBody:    map[string]interface{}{"user_id": 1},
+			expectedStatus: http.StatusUnauthorized,
+			expectedError:  "missing X-User-ID header",
+		},
+		{
+			name:           "invalid auth header returns 400",
+			userIDHeader:   "invalid",
+			requestBody:    map[string]interface{}{"user_id": 1},
+			expectedStatus: http.StatusBadRequest,
+			expectedError:  "invalid X-User-ID header",
+		},
+		{
+			name:           "IDOR attempt - reserving for another user returns 403",
+			userIDHeader:   "1",
+			requestBody:    map[string]interface{}{"user_id": 2},
+			expectedStatus: http.StatusForbidden,
+			expectedError:  "access denied",
+		},
+		{
+			name:           "valid auth - user can reserve for themselves",
+			userIDHeader:   "1",
+			requestBody:    map[string]interface{}{"user_id": 1},
+			expectedStatus: http.StatusOK,
+			expectedError:  "",
+		},
+		{
+			name:           "valid auth with large user ID",
+			userIDHeader:   "999999",
+			requestBody:    map[string]interface{}{"user_id": 999999},
+			expectedStatus: http.StatusOK,
+			expectedError:  "",
+		},
+	}
+
+	router := setupAuthTimeRestrictedTestRouter()
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			body, err := json.Marshal(tc.requestBody)
+			require.NoError(t, err)
+
+			req, err := http.NewRequest(http.MethodPost, "/reserve", bytes.NewBuffer(body))
+			require.NoError(t, err)
+			req.Header.Set("Content-Type", "application/json")
+
+			if tc.userIDHeader != "" {
+				req.Header.Set("X-User-ID", tc.userIDHeader)
+			}
+
+			recorder := httptest.NewRecorder()
+			router.ServeHTTP(recorder, req)
+
+			require.Equal(t, tc.expectedStatus, recorder.Code)
+			if tc.expectedError != "" {
+				require.Contains(t, recorder.Body.String(), tc.expectedError)
+			}
+		})
+	}
+}
+
+// TestTimeRestrictedEndpoints_InvalidRequestBody tests that endpoints properly
+// validate the request body.
+func TestTimeRestrictedEndpoints_InvalidRequestBody(t *testing.T) {
+	t.Parallel()
+
+	router := setupAuthTimeRestrictedTestRouter()
+
+	tests := []struct {
+		name        string
+		endpoint    string
+		requestBody string
+	}{
+		{
+			name:        "grab with missing user_id",
+			endpoint:    "/grab",
+			requestBody: `{}`,
+		},
+		{
+			name:        "grab with invalid user_id",
+			endpoint:    "/grab",
+			requestBody: `{"user_id": 0}`,
+		},
+		{
+			name:        "grab with negative user_id",
+			endpoint:    "/grab",
+			requestBody: `{"user_id": -1}`,
+		},
+		{
+			name:        "reserve with missing user_id",
+			endpoint:    "/reserve",
+			requestBody: `{}`,
+		},
+		{
+			name:        "reserve with invalid user_id",
+			endpoint:    "/reserve",
+			requestBody: `{"user_id": 0}`,
+		},
+		{
+			name:        "reserve with negative user_id",
+			endpoint:    "/reserve",
+			requestBody: `{"user_id": -1}`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			req, err := http.NewRequest(http.MethodPost, tc.endpoint, bytes.NewBufferString(tc.requestBody))
+			require.NoError(t, err)
+			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set("X-User-ID", "1")
+
+			recorder := httptest.NewRecorder()
+			router.ServeHTTP(recorder, req)
+
+			require.Equal(t, http.StatusBadRequest, recorder.Code)
+		})
+	}
+}

--- a/api/grab_test.go
+++ b/api/grab_test.go
@@ -100,11 +100,11 @@ func TestGrabEndpoint_Authentication(t *testing.T) {
 		},
 	}
 
-	router := setupAuthTimeRestrictedTestRouter()
-
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
+
+			router := setupAuthTimeRestrictedTestRouter()
 
 			body, err := json.Marshal(tc.requestBody)
 			require.NoError(t, err)
@@ -176,11 +176,11 @@ func TestReserveEndpoint_Authentication(t *testing.T) {
 		},
 	}
 
-	router := setupAuthTimeRestrictedTestRouter()
-
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
+
+			router := setupAuthTimeRestrictedTestRouter()
 
 			body, err := json.Marshal(tc.requestBody)
 			require.NoError(t, err)
@@ -208,8 +208,6 @@ func TestReserveEndpoint_Authentication(t *testing.T) {
 // validate the request body.
 func TestTimeRestrictedEndpoints_InvalidRequestBody(t *testing.T) {
 	t.Parallel()
-
-	router := setupAuthTimeRestrictedTestRouter()
 
 	tests := []struct {
 		name        string
@@ -252,6 +250,8 @@ func TestTimeRestrictedEndpoints_InvalidRequestBody(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
+			router := setupAuthTimeRestrictedTestRouter()
+
 			req, err := http.NewRequest(http.MethodPost, tc.endpoint, bytes.NewBufferString(tc.requestBody))
 			require.NoError(t, err)
 			req.Header.Set("Content-Type", "application/json")
@@ -261,6 +261,134 @@ func TestTimeRestrictedEndpoints_InvalidRequestBody(t *testing.T) {
 			router.ServeHTTP(recorder, req)
 
 			require.Equal(t, http.StatusBadRequest, recorder.Code)
+		})
+	}
+}
+
+// TestBoundaryValues_Int32Max tests that endpoints handle int32 max value correctly.
+func TestBoundaryValues_Int32Max(t *testing.T) {
+	t.Parallel()
+
+	const int32Max = 2147483647
+
+	tests := []struct {
+		name           string
+		endpoint       string
+		userIDHeader   string
+		requestBody    map[string]interface{}
+		expectedStatus int
+	}{
+		{
+			name:           "grab with int32 max user ID",
+			endpoint:       "/grab",
+			userIDHeader:   "2147483647",
+			requestBody:    map[string]interface{}{"user_id": int32Max},
+			expectedStatus: http.StatusOK,
+		},
+		{
+			name:           "reserve with int32 max user ID",
+			endpoint:       "/reserve",
+			userIDHeader:   "2147483647",
+			requestBody:    map[string]interface{}{"user_id": int32Max},
+			expectedStatus: http.StatusOK,
+		},
+		{
+			name:           "auth header exceeds int32 max returns 400",
+			endpoint:       "/grab",
+			userIDHeader:   "2147483648", // int32 max + 1
+			requestBody:    map[string]interface{}{"user_id": 1},
+			expectedStatus: http.StatusBadRequest,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			router := setupAuthTimeRestrictedTestRouter()
+
+			body, err := json.Marshal(tc.requestBody)
+			require.NoError(t, err)
+
+			req, err := http.NewRequest(http.MethodPost, tc.endpoint, bytes.NewBuffer(body))
+			require.NoError(t, err)
+			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set("X-User-ID", tc.userIDHeader)
+
+			recorder := httptest.NewRecorder()
+			router.ServeHTTP(recorder, req)
+
+			require.Equal(t, tc.expectedStatus, recorder.Code)
+		})
+	}
+}
+
+// TestCheckUserAuthorization tests the checkUserAuthorization helper function.
+func TestCheckUserAuthorization(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		setupContext    func(c *gin.Context)
+		requestedUserID int32
+		expectError     bool
+		expectedStatus  int
+	}{
+		{
+			name: "authorized - matching user IDs",
+			setupContext: func(c *gin.Context) {
+				c.Set("api_auth_user_id", int32(123))
+			},
+			requestedUserID: 123,
+			expectError:     false,
+			expectedStatus:  0, // No response set
+		},
+		{
+			name: "unauthorized - missing auth context",
+			setupContext: func(c *gin.Context) {
+				// Don't set auth user ID
+			},
+			requestedUserID: 123,
+			expectError:     true,
+			expectedStatus:  http.StatusUnauthorized,
+		},
+		{
+			name: "forbidden - mismatched user IDs",
+			setupContext: func(c *gin.Context) {
+				c.Set("api_auth_user_id", int32(456))
+			},
+			requestedUserID: 123,
+			expectError:     true,
+			expectedStatus:  http.StatusForbidden,
+		},
+		{
+			name: "internal error - invalid auth context type",
+			setupContext: func(c *gin.Context) {
+				c.Set("api_auth_user_id", "not-an-int32")
+			},
+			requestedUserID: 123,
+			expectError:     true,
+			expectedStatus:  http.StatusInternalServerError,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			recorder := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(recorder)
+
+			tc.setupContext(c)
+
+			err := checkUserAuthorization(c, tc.requestedUserID)
+
+			if tc.expectError {
+				require.Error(t, err)
+				require.Equal(t, tc.expectedStatus, recorder.Code)
+			} else {
+				require.NoError(t, err)
+			}
 		})
 	}
 }

--- a/api/middleware.go
+++ b/api/middleware.go
@@ -19,6 +19,7 @@ const (
 // Sentinel errors for authentication and authorization
 var (
 	ErrUnauthorized        = errors.New("unauthorized")
+	ErrAccessDenied        = errors.New("access denied")
 	ErrInternalServerError = errors.New("internal server error")
 )
 
@@ -61,6 +62,28 @@ func getUserIDFromContext(ctx *gin.Context) (int32, error) {
 	}
 
 	return userID, nil
+}
+
+// checkUserAuthorization validates that the authenticated user matches the requested user ID.
+// Returns nil if authorized, or an appropriate error with HTTP status code.
+// This helper reduces code duplication across handlers that need authorization checks.
+func checkUserAuthorization(ctx *gin.Context, requestedUserID int32) error {
+	authUserID, err := getUserIDFromContext(ctx)
+	if err != nil {
+		if errors.Is(err, ErrUnauthorized) {
+			ctx.JSON(http.StatusUnauthorized, errorResponse(err))
+		} else {
+			ctx.JSON(http.StatusInternalServerError, errorResponse(err))
+		}
+		return err
+	}
+
+	if authUserID != requestedUserID {
+		ctx.JSON(http.StatusForbidden, errorResponse(ErrAccessDenied))
+		return ErrAccessDenied
+	}
+
+	return nil
 }
 
 // specialTime is a middleware function that checks if the current time falls within

--- a/api/server.go
+++ b/api/server.go
@@ -100,9 +100,12 @@ func NewServer(store *db.Store, bfr *bloom.BloomFilter, bfg *bloom.BloomFilter, 
 		authenticated.GET("/reservation/:user_id", server.getCouponReservation)
 	}
 
-	// Time-restricted routes (only available during special time windows)
-	router.POST("/reserve", specialTime, server.createCouponReservation)
-	router.POST("/grab", specialTime, server.handleGrabRequest)
+	// Authenticated + Time-restricted routes (require auth and special time windows)
+	authenticatedTimeRestricted := router.Group("/", authMiddleware(), specialTime)
+	{
+		authenticatedTimeRestricted.POST("/reserve", server.createCouponReservation)
+		authenticatedTimeRestricted.POST("/grab", server.handleGrabRequest)
+	}
 
 	server.router = router
 

--- a/api/server.go
+++ b/api/server.go
@@ -100,8 +100,8 @@ func NewServer(store *db.Store, bfr *bloom.BloomFilter, bfg *bloom.BloomFilter, 
 		authenticated.GET("/reservation/:user_id", server.getCouponReservation)
 	}
 
-	// Authenticated + Time-restricted routes (require auth and special time windows)
-	authenticatedTimeRestricted := router.Group("/", authMiddleware(), specialTime)
+	// Time-restricted + Authenticated routes (check time window first for early rejection)
+	authenticatedTimeRestricted := router.Group("/", specialTime, authMiddleware())
 	{
 		authenticatedTimeRestricted.POST("/reserve", server.createCouponReservation)
 		authenticatedTimeRestricted.POST("/grab", server.handleGrabRequest)


### PR DESCRIPTION
## Summary
- Add `authMiddleware` to `/reserve` and `/grab` routes requiring valid `X-User-ID` header
- Add authorization checks in `createCouponReservation` handler to prevent users from creating reservations for others
- Add authorization checks in `handleGrabRequest` handler to prevent users from grabbing for others
- Add comprehensive tests covering authentication, authorization, and IDOR attack prevention

## Security Fix
This PR addresses **Issue #9: Missing Authentication on Sensitive Endpoints** (OWASP A01:2021 - Broken Access Control).

Previously, the `/reserve` and `/grab` endpoints only required time window validation but no authentication. Any anonymous user could:
- Create coupon reservations for any user ID
- Submit grab requests for any user ID

Now these endpoints require:
1. Valid `X-User-ID` authentication header
2. Authorization check ensuring the authenticated user matches the requested user_id

## Test plan
- [x] Run `go test -v ./api/... -run "TestGrabEndpoint_Authentication|TestReserveEndpoint_Authentication|TestTimeRestrictedEndpoints"` - all tests pass
- [x] Verify missing auth header returns 401 Unauthorized
- [x] Verify invalid auth header returns 400 Bad Request
- [x] Verify IDOR attempts return 403 Forbidden
- [x] Verify valid auth allows operation

Fixes #9