### PR TITLE
fix(api): sanitize error responses to prevent internal info leak

### DIFF
--- a/api/coupon_reservation.go
+++ b/api/coupon_reservation.go
@@ -116,7 +116,7 @@ func (s *Server) createCouponReservation(ctx *gin.Context) {
 	userIDStr := strconv.FormatInt(int64(req.UserID), 10)
 
 	if s.bloomFilterForReserve.TestString(userIDStr) { // Check if the user has already reserved
-		ctx.JSON(http.StatusBadRequest, errorResponse(errors.New("user already reserved")))
+		ctx.JSON(http.StatusBadRequest, errorResponse(newPublicError("user already reserved")))
 		return
 	}
 	couponReservation, err := s.store.CreateCouponReservation(ctx, req.UserID)

--- a/api/coupon_reservation_test.go
+++ b/api/coupon_reservation_test.go
@@ -55,7 +55,7 @@ func setupAuthTestRouter() *gin.Engine {
 			}
 
 			if userID != req.UserID {
-				c.JSON(http.StatusForbidden, errorResponse(errors.New("access denied")))
+				c.JSON(http.StatusForbidden, errorResponse(ErrAccessDenied))
 				return
 			}
 

--- a/api/grab.go
+++ b/api/grab.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/rand"
 	"database/sql"
-	"errors"
 	"log"
 	"math/big"
 	"net/http"
@@ -111,7 +110,7 @@ func (s *Server) handleGrabRequest(ctx *gin.Context) {
 
 	userIDStr := strconv.FormatInt(int64(req.UserID), 10)
 	if s.bloomFilterForGrab.TestString(userIDStr) { // Check if the user has already grabbed
-		ctx.JSON(http.StatusBadRequest, errorResponse(errors.New("user already grabbed")))
+		ctx.JSON(http.StatusBadRequest, errorResponse(newPublicError("user already grabbed")))
 		return
 	}
 

--- a/api/server.go
+++ b/api/server.go
@@ -137,36 +137,34 @@ func isPublicError(err error) bool {
 }
 
 // errorResponse creates a gin.H map for error responses.
-// It logs internal errors and returns sanitized messages to clients.
+// It logs only unexpected internal errors and returns sanitized messages to clients.
 func errorResponse(err error) gin.H {
-	// Log the original error for debugging
-	log.Printf("API error: %v", err)
-
-	// Check for known safe sentinel errors from middleware.go
+	// Check for known safe sentinel errors (no logging needed)
 	switch {
 	case errors.Is(err, ErrUnauthorized):
 		return gin.H{"error": "unauthorized"}
 	case errors.Is(err, ErrAccessDenied):
 		return gin.H{"error": "access denied"}
-	case errors.Is(err, ErrInternalServerError):
-		return gin.H{"error": "an internal error occurred"}
 	}
 
-	// Check if it's a public error (safe to expose)
+	// Check if it's a public error (no logging needed - expected business errors)
 	if isPublicError(err) {
 		return gin.H{"error": err.Error()}
 	}
 
-	// Handle validation errors from gin binding (safe to expose)
+	// Handle validation errors from gin binding (no logging needed - user input errors)
 	var validationErrs validator.ValidationErrors
 	if errors.As(err, &validationErrs) {
 		return gin.H{"error": err.Error()}
 	}
 
-	// Handle database "not found" errors
+	// Handle database "not found" errors (no logging needed - expected scenario)
 	if errors.Is(err, sql.ErrNoRows) {
 		return gin.H{"error": "resource not found"}
 	}
+
+	// Log only unexpected internal errors for debugging
+	log.Printf("API internal error: %v", err)
 
 	// For all other errors, return a generic message
 	return gin.H{"error": "an internal error occurred"}

--- a/api/server.go
+++ b/api/server.go
@@ -2,12 +2,16 @@ package api
 
 import (
 	"context"
+	"database/sql"
+	"errors"
+	"log"
 	"sync/atomic"
 	"time"
 
 	db "github.com/SIMPLYBOYS/shopcoupon/db/sqlc"
 	u "github.com/SIMPLYBOYS/shopcoupon/util"
 	"github.com/gin-gonic/gin"
+	"github.com/go-playground/validator/v10"
 	"github.com/willf/bloom"
 )
 
@@ -112,9 +116,60 @@ func NewServer(store *db.Store, bfr *bloom.BloomFilter, bfg *bloom.BloomFilter, 
 	return server
 }
 
-// errorResponse creates a gin.H map for error responses
+// publicError is an error type that is safe to expose to clients
+type publicError struct {
+	message string
+}
+
+func (e *publicError) Error() string {
+	return e.message
+}
+
+// newPublicError creates a new public error that is safe to expose to clients
+func newPublicError(message string) error {
+	return &publicError{message: message}
+}
+
+// isPublicError checks if an error is safe to expose to clients
+func isPublicError(err error) bool {
+	var pe *publicError
+	return errors.As(err, &pe)
+}
+
+// errorResponse creates a gin.H map for error responses.
+// It logs internal errors and returns sanitized messages to clients.
 func errorResponse(err error) gin.H {
-	return gin.H{"error": err.Error()}
+	// Log the original error for debugging
+	log.Printf("API error: %v", err)
+
+	// Check for known safe sentinel errors from middleware.go
+	switch {
+	case errors.Is(err, ErrUnauthorized):
+		return gin.H{"error": "unauthorized"}
+	case errors.Is(err, ErrAccessDenied):
+		return gin.H{"error": "access denied"}
+	case errors.Is(err, ErrInternalServerError):
+		return gin.H{"error": "an internal error occurred"}
+	}
+
+	// Check if it's a public error (safe to expose)
+	if isPublicError(err) {
+		return gin.H{"error": err.Error()}
+	}
+
+	// Handle validation errors from gin binding (safe to expose)
+	var validationErrs validator.ValidationErrors
+	if errors.As(err, &validationErrs) {
+		return gin.H{"error": err.Error()}
+	}
+
+	// Handle database "not found" errors
+	if errors.Is(err, sql.ErrNoRows) {
+		return gin.H{"error": "resource not found"}
+	}
+
+	// For all other errors, return a generic message
+	return gin.H{"error": "an internal error occurred"}
 }
 
 // Start starts background goroutines and the HTTP server.

--- a/api/user.go
+++ b/api/user.go
@@ -8,6 +8,8 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
+// Note: ErrUnauthorized, ErrAccessDenied are defined in middleware.go
+
 type getUserRequest struct {
 	ID int32 `uri:"id" binding:"required,min=1"`
 }
@@ -22,7 +24,7 @@ func (s *Server) getUser(ctx *gin.Context) {
 	// Authorization check: ensure user can only access their own data
 	userID, err := getUserIDFromContext(ctx)
 	if err != nil {
-		if err.Error() == "unauthorized" {
+		if errors.Is(err, ErrUnauthorized) {
 			ctx.JSON(http.StatusUnauthorized, errorResponse(err))
 		} else {
 			ctx.JSON(http.StatusInternalServerError, errorResponse(err))
@@ -31,7 +33,7 @@ func (s *Server) getUser(ctx *gin.Context) {
 	}
 
 	if userID != req.ID {
-		ctx.JSON(http.StatusForbidden, errorResponse(errors.New("access denied")))
+		ctx.JSON(http.StatusForbidden, errorResponse(ErrAccessDenied))
 		return
 	}
 


### PR DESCRIPTION
## Summary
- Add `publicError` type for errors safe to expose to clients
- Rewrite `errorResponse()` to log errors internally and return sanitized messages
- Handle `sql.ErrNoRows` as "resource not found"
- Use sentinel errors consistently (`ErrUnauthorized`, `ErrAccessDenied`)
- Update handlers to use `newPublicError()` for user-facing messages

## Security Fix
This PR addresses **OWASP A05:2021 Security Misconfiguration** by preventing internal error details (database schema, SQL errors, stack traces) from leaking to API clients.

**Before:** Raw error messages were returned directly to clients
```go
func errorResponse(err error) gin.H {
    return gin.H{"error": err.Error()}
}
```

**After:** Errors are logged internally and sanitized before being returned
```go
func errorResponse(err error) gin.H {
    log.Printf("API error: %v", err)
    // ... sanitization logic ...
    return gin.H{"error": "an internal error occurred"}
}
```

## Test Plan
- [x] All existing tests pass (`go test ./api/...`)
- [x] Build compiles successfully (`go build ./...`)
- [ ] Manual testing of error responses

Closes #10