### PR TITLE
fix(api): handle unique constraint errors after bloom filter reset

### DIFF
--- a/api/coupon_reservation.go
+++ b/api/coupon_reservation.go
@@ -128,6 +128,12 @@ func (s *Server) createCouponReservation(ctx *gin.Context) {
 	// DB is the source of truth - unique constraint prevents duplicates
 	couponReservation, err := s.store.CreateCouponReservation(ctx, req.UserID)
 	if err != nil {
+		// Handle unique constraint violation (user already has a reservation)
+		// This catches cases where Bloom filter was cleared but DB still has the record
+		if isUniqueViolationError(err) {
+			ctx.JSON(http.StatusBadRequest, errorResponse(newPublicError("user already reserved")))
+			return
+		}
 		ctx.JSON(http.StatusInternalServerError, errorResponse(err))
 		return
 	}

--- a/api/coupon_reservation.go
+++ b/api/coupon_reservation.go
@@ -132,6 +132,10 @@ func (s *Server) createCouponReservation(ctx *gin.Context) {
 		// This catches cases where Bloom filter was cleared or race conditions occurred
 		if isUniqueViolationError(err) {
 			log.Printf("createCouponReservation: user %d already reserved (caught by DB, bloom filter bypass)", req.UserID)
+			// Re-add to Bloom filter to prevent repeated DB hits on subsequent requests
+			s.reserveBloomMu.Lock()
+			s.bloomFilterForReserve.AddString(userIDStr)
+			s.reserveBloomMu.Unlock()
 			ctx.JSON(http.StatusBadRequest, errorResponse(newPublicError("user already reserved")))
 			return
 		}

--- a/api/coupon_reservation.go
+++ b/api/coupon_reservation.go
@@ -129,8 +129,9 @@ func (s *Server) createCouponReservation(ctx *gin.Context) {
 	couponReservation, err := s.store.CreateCouponReservation(ctx, req.UserID)
 	if err != nil {
 		// Handle unique constraint violation (user already has a reservation)
-		// This catches cases where Bloom filter was cleared but DB still has the record
+		// This catches cases where Bloom filter was cleared or race conditions occurred
 		if isUniqueViolationError(err) {
+			log.Printf("createCouponReservation: user %d already reserved (caught by DB, bloom filter bypass)", req.UserID)
 			ctx.JSON(http.StatusBadRequest, errorResponse(newPublicError("user already reserved")))
 			return
 		}

--- a/api/grab.go
+++ b/api/grab.go
@@ -232,11 +232,11 @@ func updateCouponsForWinners(ctx context.Context, store *db.Store, workPool chan
 			_, err := store.Queries.UpdateCoupon(ctx, arg) // Update the coupon
 			if err != nil {
 				// Log unique constraint violations separately for debugging
-				// This can happen if Bloom filter was cleared and user tried to grab again
+				// This can happen if Bloom filter was cleared or race conditions occurred
 				if isUniqueViolationError(err) {
 					log.Printf("updateCouponsForWinners: user %d already has a coupon (unique constraint)", userId)
 				} else {
-					log.Println("handleGrabbing error:", err)
+					log.Printf("updateCouponsForWinners error: %v", err)
 				}
 			}
 

--- a/api/grab.go
+++ b/api/grab.go
@@ -231,7 +231,13 @@ func updateCouponsForWinners(ctx context.Context, store *db.Store, workPool chan
 			}
 			_, err := store.Queries.UpdateCoupon(ctx, arg) // Update the coupon
 			if err != nil {
-				log.Println("handleGrabbing error:", err)
+				// Log unique constraint violations separately for debugging
+				// This can happen if Bloom filter was cleared and user tried to grab again
+				if isUniqueViolationError(err) {
+					log.Printf("updateCouponsForWinners: user %d already has a coupon (unique constraint)", userId)
+				} else {
+					log.Println("handleGrabbing error:", err)
+				}
 			}
 
 			workPool <- struct{}{} // Return the worker to the pool

--- a/api/server.go
+++ b/api/server.go
@@ -134,6 +134,9 @@ const (
 // isUniqueViolationError checks if the error is a PostgreSQL unique constraint violation.
 // This is used to detect when a duplicate entry is attempted (e.g., user already reserved).
 func isUniqueViolationError(err error) bool {
+	if err == nil {
+		return false
+	}
 	var pqErr *pq.Error
 	if errors.As(err, &pqErr) {
 		return pqErr.Code == pqUniqueViolation

--- a/api/server.go
+++ b/api/server.go
@@ -13,6 +13,7 @@ import (
 	u "github.com/SIMPLYBOYS/shopcoupon/util"
 	"github.com/gin-gonic/gin"
 	"github.com/go-playground/validator/v10"
+	"github.com/lib/pq"
 	"github.com/willf/bloom"
 )
 
@@ -123,6 +124,21 @@ func NewServer(store *db.Store, bfr *bloom.BloomFilter, bfg *bloom.BloomFilter, 
 	server.router = router
 
 	return server
+}
+
+// PostgreSQL error codes
+const (
+	pqUniqueViolation = "23505" // unique_violation error code
+)
+
+// isUniqueViolationError checks if the error is a PostgreSQL unique constraint violation.
+// This is used to detect when a duplicate entry is attempted (e.g., user already reserved).
+func isUniqueViolationError(err error) bool {
+	var pqErr *pq.Error
+	if errors.As(err, &pqErr) {
+		return pqErr.Code == pqUniqueViolation
+	}
+	return false
 }
 
 // publicError is an error type that is safe to expose to clients


### PR DESCRIPTION
## Summary
- Add proper error handling for PostgreSQL unique constraint violations (error code 23505)
- Return user-friendly "user already reserved" message instead of 500 Internal Server Error when users attempt duplicate reservations after daily Bloom filter reset
- Improve logging for duplicate grab attempts to aid debugging

## Changes
- `api/server.go`: Add `isUniqueViolationError` helper function using `lib/pq`
- `api/coupon_reservation.go`: Handle unique constraint violation in `createCouponReservation`
- `api/grab.go`: Improve error logging in `updateCouponsForWinners`

## Test plan
- [x] Build passes
- [x] API tests pass
- [ ] Manual test: Attempt duplicate reservation after Bloom filter is cleared - should return 400 with "user already reserved"

Closes #12

🤖 Generated with [Claude Code](https://claude.ai/code)