### PR TITLE
fix(security): prevent coupon code enumeration attack

### DIFF
--- a/api/coupon.go
+++ b/api/coupon.go
@@ -1,27 +1,43 @@
 package api
 
 import (
+	"errors"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
 )
 
 type getCouponRequest struct {
-	CODE string `uri:"code" binding:"required,min=1"`
+	Code string `uri:"code" binding:"required,min=1"`
 }
 
 func (s *Server) getCoupon(ctx *gin.Context) {
-
 	var req getCouponRequest
 	if err := ctx.ShouldBindUri(&req); err != nil {
 		ctx.JSON(http.StatusBadRequest, errorResponse(err))
 		return
 	}
 
-	coupon, err := s.store.GetCoupon(ctx, req.CODE)
+	// Get authenticated user ID
+	userID, err := getUserIDFromContext(ctx)
+	if err != nil {
+		if errors.Is(err, ErrUnauthorized) {
+			ctx.JSON(http.StatusUnauthorized, errorResponse(err))
+		} else {
+			ctx.JSON(http.StatusInternalServerError, errorResponse(err))
+		}
+		return
+	}
 
+	coupon, err := s.store.GetCoupon(ctx, req.Code)
 	if err != nil {
 		ctx.JSON(http.StatusInternalServerError, errorResponse(err))
+		return
+	}
+
+	// Authorization check: only coupon owner can view the coupon
+	if !coupon.UserID.Valid || coupon.UserID.Int32 != userID {
+		ctx.JSON(http.StatusForbidden, errorResponse(ErrAccessDenied))
 		return
 	}
 

--- a/api/coupon.go
+++ b/api/coupon.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"database/sql"
 	"errors"
 	"net/http"
 
@@ -31,7 +32,11 @@ func (s *Server) getCoupon(ctx *gin.Context) {
 
 	coupon, err := s.store.GetCoupon(ctx, req.Code)
 	if err != nil {
-		ctx.JSON(http.StatusInternalServerError, errorResponse(err))
+		if errors.Is(err, sql.ErrNoRows) {
+			ctx.JSON(http.StatusNotFound, errorResponse(err))
+		} else {
+			ctx.JSON(http.StatusInternalServerError, errorResponse(err))
+		}
 		return
 	}
 

--- a/api/coupon_test.go
+++ b/api/coupon_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"database/sql"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -32,7 +33,11 @@ func setupCouponTestRouter(coupons map[string]mockCoupon) *gin.Engine {
 
 			userID, err := getUserIDFromContext(c)
 			if err != nil {
-				c.JSON(http.StatusUnauthorized, errorResponse(ErrUnauthorized))
+				if errors.Is(err, ErrUnauthorized) {
+					c.JSON(http.StatusUnauthorized, errorResponse(err))
+				} else {
+					c.JSON(http.StatusInternalServerError, errorResponse(err))
+				}
 				return
 			}
 

--- a/api/coupon_test.go
+++ b/api/coupon_test.go
@@ -1,0 +1,249 @@
+package api
+
+import (
+	"database/sql"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+// mockCoupon simulates a coupon for testing authorization logic
+type mockCoupon struct {
+	Code   string
+	UserID sql.NullInt32
+}
+
+// setupCouponTestRouter creates a test router with auth middleware and a handler
+// that mimics the authorization logic of getCoupon without database dependencies.
+func setupCouponTestRouter(coupons map[string]mockCoupon) *gin.Engine {
+	router := gin.New()
+
+	authenticated := router.Group("/", authMiddleware())
+	{
+		authenticated.GET("/coupon/:code", func(c *gin.Context) {
+			var req getCouponRequest
+			if err := c.ShouldBindUri(&req); err != nil {
+				c.JSON(http.StatusBadRequest, errorResponse(err))
+				return
+			}
+
+			userID, err := getUserIDFromContext(c)
+			if err != nil {
+				c.JSON(http.StatusUnauthorized, errorResponse(ErrUnauthorized))
+				return
+			}
+
+			coupon, exists := coupons[req.Code]
+			if !exists {
+				c.JSON(http.StatusNotFound, gin.H{"error": "coupon not found"})
+				return
+			}
+
+			// Authorization check: only coupon owner can view the coupon
+			if !coupon.UserID.Valid || coupon.UserID.Int32 != userID {
+				c.JSON(http.StatusForbidden, errorResponse(ErrAccessDenied))
+				return
+			}
+
+			c.JSON(http.StatusOK, coupon)
+		})
+	}
+
+	return router
+}
+
+// TestGetCoupon_Authentication tests that the /coupon/:code endpoint requires authentication.
+func TestGetCoupon_Authentication(t *testing.T) {
+	t.Parallel()
+
+	coupons := map[string]mockCoupon{
+		"COUPON-ABC123": {Code: "COUPON-ABC123", UserID: sql.NullInt32{Int32: 1, Valid: true}},
+	}
+
+	tests := []struct {
+		name           string
+		userIDHeader   string
+		couponCode     string
+		expectedStatus int
+		expectedError  string
+	}{
+		{
+			name:           "missing auth header returns 401",
+			userIDHeader:   "",
+			couponCode:     "COUPON-ABC123",
+			expectedStatus: http.StatusUnauthorized,
+			expectedError:  "missing X-User-ID header",
+		},
+		{
+			name:           "invalid auth header returns 400",
+			userIDHeader:   "invalid",
+			couponCode:     "COUPON-ABC123",
+			expectedStatus: http.StatusBadRequest,
+			expectedError:  "invalid X-User-ID header",
+		},
+		{
+			name:           "negative user ID returns 400",
+			userIDHeader:   "-1",
+			couponCode:     "COUPON-ABC123",
+			expectedStatus: http.StatusBadRequest,
+			expectedError:  "invalid X-User-ID header",
+		},
+		{
+			name:           "zero user ID returns 400",
+			userIDHeader:   "0",
+			couponCode:     "COUPON-ABC123",
+			expectedStatus: http.StatusBadRequest,
+			expectedError:  "invalid X-User-ID header",
+		},
+	}
+
+	router := setupCouponTestRouter(coupons)
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			req, err := http.NewRequest(http.MethodGet, "/coupon/"+tc.couponCode, nil)
+			require.NoError(t, err)
+
+			if tc.userIDHeader != "" {
+				req.Header.Set("X-User-ID", tc.userIDHeader)
+			}
+
+			recorder := httptest.NewRecorder()
+			router.ServeHTTP(recorder, req)
+
+			require.Equal(t, tc.expectedStatus, recorder.Code)
+			require.Contains(t, recorder.Body.String(), tc.expectedError)
+		})
+	}
+}
+
+// TestGetCoupon_Authorization tests that the /coupon/:code endpoint
+// properly enforces authorization - only coupon owner can view their coupon.
+func TestGetCoupon_Authorization(t *testing.T) {
+	t.Parallel()
+
+	coupons := map[string]mockCoupon{
+		"COUPON-USER1": {Code: "COUPON-USER1", UserID: sql.NullInt32{Int32: 1, Valid: true}},
+		"COUPON-USER2": {Code: "COUPON-USER2", UserID: sql.NullInt32{Int32: 2, Valid: true}},
+		"COUPON-UNASSIGNED": {Code: "COUPON-UNASSIGNED", UserID: sql.NullInt32{Valid: false}},
+	}
+
+	tests := []struct {
+		name           string
+		userIDHeader   string
+		couponCode     string
+		expectedStatus int
+		expectedError  string
+	}{
+		{
+			name:           "owner can access their own coupon",
+			userIDHeader:   "1",
+			couponCode:     "COUPON-USER1",
+			expectedStatus: http.StatusOK,
+			expectedError:  "",
+		},
+		{
+			name:           "user cannot access another user's coupon",
+			userIDHeader:   "1",
+			couponCode:     "COUPON-USER2",
+			expectedStatus: http.StatusForbidden,
+			expectedError:  "access denied",
+		},
+		{
+			name:           "user cannot access unassigned coupon",
+			userIDHeader:   "1",
+			couponCode:     "COUPON-UNASSIGNED",
+			expectedStatus: http.StatusForbidden,
+			expectedError:  "access denied",
+		},
+		{
+			name:           "different user cannot access unassigned coupon",
+			userIDHeader:   "999",
+			couponCode:     "COUPON-UNASSIGNED",
+			expectedStatus: http.StatusForbidden,
+			expectedError:  "access denied",
+		},
+		{
+			name:           "non-existent coupon returns 404",
+			userIDHeader:   "1",
+			couponCode:     "COUPON-NONEXISTENT",
+			expectedStatus: http.StatusNotFound,
+			expectedError:  "coupon not found",
+		},
+	}
+
+	router := setupCouponTestRouter(coupons)
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			req, err := http.NewRequest(http.MethodGet, "/coupon/"+tc.couponCode, nil)
+			require.NoError(t, err)
+			req.Header.Set("X-User-ID", tc.userIDHeader)
+
+			recorder := httptest.NewRecorder()
+			router.ServeHTTP(recorder, req)
+
+			require.Equal(t, tc.expectedStatus, recorder.Code)
+			if tc.expectedError != "" {
+				require.Contains(t, recorder.Body.String(), tc.expectedError)
+			}
+		})
+	}
+}
+
+// TestGetCoupon_ValidAccess tests successful access scenarios.
+func TestGetCoupon_ValidAccess(t *testing.T) {
+	t.Parallel()
+
+	coupons := map[string]mockCoupon{
+		"COUPON-USER1":   {Code: "COUPON-USER1", UserID: sql.NullInt32{Int32: 1, Valid: true}},
+		"COUPON-USER100": {Code: "COUPON-USER100", UserID: sql.NullInt32{Int32: 100, Valid: true}},
+		"COUPON-MAXINT":  {Code: "COUPON-MAXINT", UserID: sql.NullInt32{Int32: 2147483647, Valid: true}},
+	}
+
+	tests := []struct {
+		name         string
+		userIDHeader string
+		couponCode   string
+	}{
+		{
+			name:         "user 1 can access their coupon",
+			userIDHeader: "1",
+			couponCode:   "COUPON-USER1",
+		},
+		{
+			name:         "user 100 can access their coupon",
+			userIDHeader: "100",
+			couponCode:   "COUPON-USER100",
+		},
+		{
+			name:         "user with max int32 ID can access their coupon",
+			userIDHeader: "2147483647",
+			couponCode:   "COUPON-MAXINT",
+		},
+	}
+
+	router := setupCouponTestRouter(coupons)
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			req, err := http.NewRequest(http.MethodGet, "/coupon/"+tc.couponCode, nil)
+			require.NoError(t, err)
+			req.Header.Set("X-User-ID", tc.userIDHeader)
+
+			recorder := httptest.NewRecorder()
+			router.ServeHTTP(recorder, req)
+
+			require.Equal(t, http.StatusOK, recorder.Code)
+		})
+	}
+}

--- a/api/server.go
+++ b/api/server.go
@@ -104,7 +104,6 @@ func NewServer(store *db.Store, bfr *bloom.BloomFilter, bfg *bloom.BloomFilter, 
 	router := gin.Default()
 
 	// Public routes (no authentication required)
-	router.GET("/coupon/:code", server.getCoupon)
 	router.POST("/user", server.createUser)
 
 	// Authenticated routes (require valid X-User-ID header)
@@ -112,6 +111,7 @@ func NewServer(store *db.Store, bfr *bloom.BloomFilter, bfg *bloom.BloomFilter, 
 	{
 		authenticated.GET("/user/:id", server.getUser)
 		authenticated.GET("/reservation/:user_id", server.getCouponReservation)
+		authenticated.GET("/coupon/:code", server.getCoupon)
 	}
 
 	// Time-restricted + Authenticated routes (check time window first for early rejection)

--- a/util/coupon.go
+++ b/util/coupon.go
@@ -4,24 +4,20 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
-	"time"
 )
 
 func GenerateCouponCode() (string, error) {
-	// Generate 8 random bytes
-	bytes := make([]byte, 8)
+	// Generate 16 random bytes (128-bit entropy) for unpredictable coupon codes
+	bytes := make([]byte, 16)
 	if _, err := rand.Read(bytes); err != nil {
 		return "", fmt.Errorf("generating coupon code: %w", err)
 	}
 
-	// Convert bytes to a hexadecimal string
+	// Convert bytes to a hexadecimal string (32 characters)
 	randomHex := hex.EncodeToString(bytes)
 
-	// Generate a timestamp
-	timestamp := time.Now().UnixNano()
-
-	// Construct the coupon code
-	couponCode := fmt.Sprintf("COUPON-%s-%d", randomHex, timestamp)
+	// Construct the coupon code without timestamp to prevent enumeration
+	couponCode := fmt.Sprintf("COUPON-%s", randomHex)
 
 	return couponCode, nil
 }


### PR DESCRIPTION
## Summary
- Remove predictable timestamp from coupon code generation (128-bit entropy)
- Move `/coupon/:code` endpoint to authenticated routes
- Add authorization check: only coupon owner can view their coupon details

## Changes
| File | Change |
|------|--------|
| `util/coupon.go` | Remove timestamp, increase random bytes from 8 to 16 |
| `api/server.go` | Move route to authenticated group |
| `api/coupon.go` | Add auth + authorization check |

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./api/...` passes  
- [x] `go vet ./...` passes
- [ ] Manual test: unauthenticated request to `/coupon/:code` returns 401
- [ ] Manual test: authenticated user accessing another user's coupon returns 403
- [ ] Manual test: coupon owner can view their own coupon (200)

Closes #14

🤖 Generated with [Claude Code](https://claude.ai/code)