### PR TITLE
perf(db): fix N+1 query patterns in coupon processing

### DIFF
--- a/api/coupon_reservation.go
+++ b/api/coupon_reservation.go
@@ -155,9 +155,10 @@ func (s *Server) createCouponReservation(ctx *gin.Context) {
 }
 
 // generateCouponsForReservations generates coupons for the given reservations
-// Uses batch operations to minimize database round trips:
+// Uses batch operations with transaction protection to ensure atomicity:
 // - Batch INSERT for creating coupons
 // - Batch UPDATE for marking reservations as processed
+// Both operations are wrapped in a transaction to prevent data inconsistency
 func generateCouponsForReservations(ctx context.Context, store *db.Store, reservations []db.CouponReservations, numCoupons int) int {
 	if len(reservations) == 0 {
 		return 0
@@ -169,29 +170,35 @@ func generateCouponsForReservations(ctx context.Context, store *db.Store, reserv
 		couponsToCreate = len(reservations)
 	}
 
-	// Collect all reservation IDs to mark as processed
-	allReservationIDs := make([]int32, len(reservations))
-	for i, r := range reservations {
-		allReservationIDs[i] = r.ID
-	}
+	// Separate reservations into winners (get coupons) and non-winners (just mark processed)
+	winnerReservationIDs := make([]int32, 0, couponsToCreate)
+	nonWinnerReservationIDs := make([]int32, 0, len(reservations)-couponsToCreate)
 
 	// Generate coupon codes for winners (up to numCoupons)
 	couponCodes := make([]string, 0, couponsToCreate)
-	couponReservationIDs := make([]int32, 0, couponsToCreate)
+	failedCodeGenIDs := make([]int32, 0) // Track reservations where code generation failed
 
-	for i := 0; i < couponsToCreate && i < len(reservations); i++ {
-		couponCode, err := u.GenerateCouponCode()
-		if err != nil {
-			log.Printf("generateCouponsForReservations GenerateCouponCode error for reservation %d: %v", reservations[i].ID, err)
-			continue
+	for i := 0; i < len(reservations); i++ {
+		if i < couponsToCreate {
+			// This reservation should get a coupon
+			couponCode, err := u.GenerateCouponCode()
+			if err != nil {
+				log.Printf("generateCouponsForReservations GenerateCouponCode error for reservation %d: %v", reservations[i].ID, err)
+				// Don't mark as processed - allow retry on next cycle
+				failedCodeGenIDs = append(failedCodeGenIDs, reservations[i].ID)
+				continue
+			}
+			couponCodes = append(couponCodes, couponCode)
+			winnerReservationIDs = append(winnerReservationIDs, reservations[i].ID)
+		} else {
+			// This reservation doesn't get a coupon, just mark as processed
+			nonWinnerReservationIDs = append(nonWinnerReservationIDs, reservations[i].ID)
 		}
-		couponCodes = append(couponCodes, couponCode)
-		couponReservationIDs = append(couponReservationIDs, reservations[i].ID)
 	}
 
 	couponsGenerated := 0
 
-	// Batch create coupons if we have any codes
+	// Use transaction to create coupons and mark winner reservations as processed atomically
 	if len(couponCodes) > 0 {
 		batchParams := db.BatchCreateCouponsParams{
 			Codes:      couponCodes,
@@ -199,41 +206,73 @@ func generateCouponsForReservations(ctx context.Context, store *db.Store, reserv
 			ExpiryDate: time.Now().AddDate(0, 0, 7), // Expiry date is 7 days from now
 		}
 
-		created, err := store.Queries.BatchCreateCoupons(ctx, batchParams)
+		created, err := store.BatchCreateCouponsWithTx(ctx, batchParams, winnerReservationIDs)
 		if err != nil {
-			log.Printf("generateCouponsForReservations BatchCreateCoupons error: %v", err)
-			// Fall back to individual creation if batch fails
-			for i, code := range couponCodes {
-				arg := db.CreateCouponParams{
-					Code:       code,
-					Discount:   batchParams.Discount,
-					ExpiryDate: batchParams.ExpiryDate,
-				}
-				_, err := store.Queries.CreateCoupon(ctx, arg)
-				if err != nil {
-					log.Printf("generateCouponsForReservations CreateCoupon fallback error for reservation %d: %v", couponReservationIDs[i], err)
-				} else {
-					couponsGenerated++
-				}
-			}
+			log.Printf("generateCouponsForReservations BatchCreateCouponsWithTx error: %v", err)
+			// Fall back to individual creation with immediate marking
+			couponsGenerated = fallbackCreateCouponsIndividually(ctx, store, couponCodes, winnerReservationIDs, batchParams)
 		} else {
 			couponsGenerated = int(created)
+			log.Printf("generateCouponsForReservations: created %d coupons and marked %d reservations in transaction", created, len(winnerReservationIDs))
 		}
 	}
 
-	// Batch mark all reservations as processed
-	if len(allReservationIDs) > 0 {
-		err := store.Queries.BatchMarkCouponReservationsAsProcessed(ctx, allReservationIDs)
+	// Mark non-winner reservations as processed (separate from winners)
+	if len(nonWinnerReservationIDs) > 0 {
+		err := store.Queries.BatchMarkCouponReservationsAsProcessed(ctx, nonWinnerReservationIDs)
 		if err != nil {
-			log.Printf("generateCouponsForReservations BatchMarkCouponReservationsAsProcessed error: %v", err)
-			// Fall back to individual marking if batch fails
-			for _, id := range allReservationIDs {
+			log.Printf("generateCouponsForReservations BatchMarkNonWinners error: %v", err)
+			// Fall back to individual marking
+			successCount := 0
+			for _, id := range nonWinnerReservationIDs {
 				if markErr := store.Queries.MarkCouponReservationAsProcessed(ctx, id); markErr != nil {
 					log.Printf("generateCouponsForReservations MarkAsProcessed fallback error for reservation %d: %v", id, markErr)
+				} else {
+					successCount++
 				}
 			}
+			log.Printf("generateCouponsForReservations: fallback marked %d/%d non-winner reservations", successCount, len(nonWinnerReservationIDs))
 		}
 	}
 
+	// Log failed code generations (these will be retried on next cycle)
+	if len(failedCodeGenIDs) > 0 {
+		log.Printf("generateCouponsForReservations: %d reservations had code generation failures, will retry next cycle", len(failedCodeGenIDs))
+	}
+
+	return couponsGenerated
+}
+
+// fallbackCreateCouponsIndividually creates coupons one by one when batch operation fails
+// Each successful coupon creation immediately marks its reservation as processed
+func fallbackCreateCouponsIndividually(ctx context.Context, store *db.Store, codes []string, reservationIDs []int32, params db.BatchCreateCouponsParams) int {
+	couponsGenerated := 0
+
+	for i, code := range codes {
+		if i >= len(reservationIDs) {
+			break
+		}
+
+		arg := db.CreateCouponParams{
+			Code:       code,
+			Discount:   params.Discount,
+			ExpiryDate: params.ExpiryDate,
+		}
+
+		_, err := store.Queries.CreateCoupon(ctx, arg)
+		if err != nil {
+			log.Printf("fallbackCreateCouponsIndividually CreateCoupon error for reservation %d: %v", reservationIDs[i], err)
+			// Don't mark as processed - allow retry
+			continue
+		}
+
+		// Only mark as processed after successful coupon creation
+		if markErr := store.Queries.MarkCouponReservationAsProcessed(ctx, reservationIDs[i]); markErr != nil {
+			log.Printf("CRITICAL: coupon created but MarkAsProcessed failed for reservation %d: %v", reservationIDs[i], markErr)
+		}
+		couponsGenerated++
+	}
+
+	log.Printf("fallbackCreateCouponsIndividually: created %d/%d coupons", couponsGenerated, len(codes))
 	return couponsGenerated
 }

--- a/api/coupon_reservation.go
+++ b/api/coupon_reservation.go
@@ -6,7 +6,6 @@ import (
 	"log"
 	"net/http"
 	"strconv"
-	"sync"
 	"time"
 
 	db "github.com/SIMPLYBOYS/shopcoupon/db/sqlc"
@@ -156,77 +155,85 @@ func (s *Server) createCouponReservation(ctx *gin.Context) {
 }
 
 // generateCouponsForReservations generates coupons for the given reservations
-// Note: Each coupon creation is independent, so we don't use a transaction here.
-// Using transactions across goroutines is problematic and not needed for this use case.
+// Uses batch operations to minimize database round trips:
+// - Batch INSERT for creating coupons
+// - Batch UPDATE for marking reservations as processed
 func generateCouponsForReservations(ctx context.Context, store *db.Store, reservations []db.CouponReservations, numCoupons int) int {
-	couponsGenerated := 0
-	var mu sync.Mutex // Mutex to protect couponsGenerated
-
-	var wg sync.WaitGroup
-	batchSize := 500 // Adjust batch size as needed
-	for i := 0; i < len(reservations); i += batchSize {
-		end := i + batchSize
-		if end > len(reservations) {
-			end = len(reservations)
-		}
-
-		wg.Add(1)
-		go func(start, end int) {
-			defer wg.Done()
-			for j := start; j < end; j++ {
-				reservation := reservations[j]
-
-				mu.Lock()
-				reachedLimit := couponsGenerated >= numCoupons
-				mu.Unlock()
-
-				if reachedLimit {
-					err := store.Queries.MarkCouponReservationAsProcessed(ctx, reservation.ID)
-					if err != nil {
-						log.Println("generateCouponsForReservations error:", err)
-					}
-					continue
-				}
-
-				couponCode, err := u.GenerateCouponCode()
-				if err != nil {
-					log.Printf("generateCouponsForReservations GenerateCouponCode error for reservation %d: %v", reservation.ID, err)
-					if markErr := store.Queries.MarkCouponReservationAsProcessed(ctx, reservation.ID); markErr != nil {
-						log.Printf("generateCouponsForReservations MarkAsProcessed error for reservation %d: %v", reservation.ID, markErr)
-					}
-					continue
-				}
-
-				arg := db.CreateCouponParams{
-					Code:       couponCode,
-					Discount:   "0.25",                      // 25% discount
-					ExpiryDate: time.Now().AddDate(0, 0, 7), // Expiry date is 7 days from now
-				}
-
-				_, err = store.Queries.CreateCoupon(ctx, arg)
-				if err != nil {
-					log.Printf("generateCouponsForReservations CreateCoupon error for reservation %d: %v", reservation.ID, err)
-					// Mark as processed to prevent infinite retry loop
-					if markErr := store.Queries.MarkCouponReservationAsProcessed(ctx, reservation.ID); markErr != nil {
-						log.Printf("generateCouponsForReservations MarkAsProcessed error for reservation %d: %v", reservation.ID, markErr)
-					}
-					continue
-				}
-
-				mu.Lock()
-				couponsGenerated++
-				mu.Unlock()
-
-				err = store.Queries.MarkCouponReservationAsProcessed(ctx, reservation.ID)
-				if err != nil {
-					// Critical: coupon created but reservation not marked - potential duplicate risk
-					log.Printf("CRITICAL: coupon created but MarkAsProcessed failed for reservation %d: %v", reservation.ID, err)
-				}
-			}
-		}(i, end)
+	if len(reservations) == 0 {
+		return 0
 	}
 
-	wg.Wait()
+	// Determine how many coupons we can actually create
+	couponsToCreate := numCoupons
+	if couponsToCreate > len(reservations) {
+		couponsToCreate = len(reservations)
+	}
+
+	// Collect all reservation IDs to mark as processed
+	allReservationIDs := make([]int32, len(reservations))
+	for i, r := range reservations {
+		allReservationIDs[i] = r.ID
+	}
+
+	// Generate coupon codes for winners (up to numCoupons)
+	couponCodes := make([]string, 0, couponsToCreate)
+	couponReservationIDs := make([]int32, 0, couponsToCreate)
+
+	for i := 0; i < couponsToCreate && i < len(reservations); i++ {
+		couponCode, err := u.GenerateCouponCode()
+		if err != nil {
+			log.Printf("generateCouponsForReservations GenerateCouponCode error for reservation %d: %v", reservations[i].ID, err)
+			continue
+		}
+		couponCodes = append(couponCodes, couponCode)
+		couponReservationIDs = append(couponReservationIDs, reservations[i].ID)
+	}
+
+	couponsGenerated := 0
+
+	// Batch create coupons if we have any codes
+	if len(couponCodes) > 0 {
+		batchParams := db.BatchCreateCouponsParams{
+			Codes:      couponCodes,
+			Discount:   "0.25",                      // 25% discount
+			ExpiryDate: time.Now().AddDate(0, 0, 7), // Expiry date is 7 days from now
+		}
+
+		created, err := store.Queries.BatchCreateCoupons(ctx, batchParams)
+		if err != nil {
+			log.Printf("generateCouponsForReservations BatchCreateCoupons error: %v", err)
+			// Fall back to individual creation if batch fails
+			for i, code := range couponCodes {
+				arg := db.CreateCouponParams{
+					Code:       code,
+					Discount:   batchParams.Discount,
+					ExpiryDate: batchParams.ExpiryDate,
+				}
+				_, err := store.Queries.CreateCoupon(ctx, arg)
+				if err != nil {
+					log.Printf("generateCouponsForReservations CreateCoupon fallback error for reservation %d: %v", couponReservationIDs[i], err)
+				} else {
+					couponsGenerated++
+				}
+			}
+		} else {
+			couponsGenerated = int(created)
+		}
+	}
+
+	// Batch mark all reservations as processed
+	if len(allReservationIDs) > 0 {
+		err := store.Queries.BatchMarkCouponReservationsAsProcessed(ctx, allReservationIDs)
+		if err != nil {
+			log.Printf("generateCouponsForReservations BatchMarkCouponReservationsAsProcessed error: %v", err)
+			// Fall back to individual marking if batch fails
+			for _, id := range allReservationIDs {
+				if markErr := store.Queries.MarkCouponReservationAsProcessed(ctx, id); markErr != nil {
+					log.Printf("generateCouponsForReservations MarkAsProcessed fallback error for reservation %d: %v", id, markErr)
+				}
+			}
+		}
+	}
 
 	return couponsGenerated
 }

--- a/api/grab.go
+++ b/api/grab.go
@@ -199,24 +199,55 @@ func receiveGrabRequests(grabRequestChan <-chan *struct {
 }
 
 // updateCouponsForWinners updates the coupons for winners
-// Note: Each coupon update is independent, so we don't use a transaction here.
+// Uses batch UPDATE to minimize database round trips instead of individual updates
 func updateCouponsForWinners(ctx context.Context, store *db.Store, workPool chan struct{}, coupons []db.Coupons, winners []int) {
-	var winnersMutex sync.Mutex
+	if len(winners) == 0 || len(coupons) == 0 {
+		return
+	}
+
+	// Prepare batch assignment parameters
+	numToAssign := len(winners)
+	if numToAssign > len(coupons) {
+		numToAssign = len(coupons)
+	}
+
+	couponIDs := make([]int32, numToAssign)
+	userIDs := make([]int32, numToAssign)
+
+	for i := 0; i < numToAssign; i++ {
+		couponIDs[i] = coupons[i].ID
+		userIDs[i] = int32(winners[i])
+	}
+
+	// Use batch operation for assigning coupons to users
+	batchParams := db.BatchAssignCouponsToUsersParams{
+		CouponIDs: couponIDs,
+		UserIDs:   userIDs,
+	}
+
+	rowsAffected, err := store.Queries.BatchAssignCouponsToUsers(ctx, batchParams)
+	if err != nil {
+		log.Printf("updateCouponsForWinners BatchAssignCouponsToUsers error: %v", err)
+		// Fall back to individual updates if batch fails
+		fallbackUpdateCouponsForWinners(ctx, store, workPool, coupons, winners)
+		return
+	}
+
+	log.Printf("updateCouponsForWinners: batch assigned %d coupons to users", rowsAffected)
+}
+
+// fallbackUpdateCouponsForWinners provides a fallback mechanism using individual updates
+// This is used when the batch operation fails
+func fallbackUpdateCouponsForWinners(ctx context.Context, store *db.Store, workPool chan struct{}, coupons []db.Coupons, winners []int) {
 	var wg sync.WaitGroup
 
-	for i := 0; i < len(winners); i++ {
+	for i := 0; i < len(winners) && i < len(coupons); i++ {
 		wg.Add(1)
 		go func(index int) {
 			defer wg.Done()
 			<-workPool // Get a worker from the pool
 
-			winnersMutex.Lock()
-			userId := 0
-			if index < len(winners) {
-				userId = winners[index]
-			}
-			winnersMutex.Unlock()
-
+			userId := winners[index]
 			discount := coupons[index].Discount
 			if discount == "" {
 				discount = "0.25"
@@ -229,14 +260,12 @@ func updateCouponsForWinners(ctx context.Context, store *db.Store, workPool chan
 				IsUsed:     true,
 				UserID:     sql.NullInt32{Int32: int32(userId), Valid: true},
 			}
-			_, err := store.Queries.UpdateCoupon(ctx, arg) // Update the coupon
+			_, err := store.Queries.UpdateCoupon(ctx, arg)
 			if err != nil {
-				// Log unique constraint violations separately for debugging
-				// This can happen if Bloom filter was cleared or race conditions occurred
 				if isUniqueViolationError(err) {
-					log.Printf("updateCouponsForWinners: user %d already has a coupon (unique constraint)", userId)
+					log.Printf("fallbackUpdateCouponsForWinners: user %d already has a coupon (unique constraint)", userId)
 				} else {
-					log.Printf("updateCouponsForWinners error: %v", err)
+					log.Printf("fallbackUpdateCouponsForWinners error: %v", err)
 				}
 			}
 

--- a/api/grab.go
+++ b/api/grab.go
@@ -254,8 +254,28 @@ func fallbackUpdateCouponsForWinners(ctx context.Context, store *db.Store, workP
 		wg.Add(1)
 		go func(index int) {
 			defer wg.Done()
-			<-workPool // Get a worker from the pool
-			defer func() { workPool <- struct{}{} }() // Return the worker to the pool
+
+			// Safely get a worker from the pool with context cancellation support
+			select {
+			case <-workPool:
+				// Got a worker, continue
+			case <-ctx.Done():
+				mu.Lock()
+				failCount++
+				mu.Unlock()
+				log.Printf("fallbackUpdateCouponsForWinners: context cancelled for user %d", winners[index])
+				return
+			}
+
+			// Safely return the worker to the pool
+			defer func() {
+				select {
+				case workPool <- struct{}{}:
+					// Worker returned successfully
+				default:
+					// Pool is full or closed, ignore
+				}
+			}()
 
 			userId := winners[index]
 			discount := coupons[index].Discount

--- a/api/grab.go
+++ b/api/grab.go
@@ -237,15 +237,25 @@ func updateCouponsForWinners(ctx context.Context, store *db.Store, workPool chan
 }
 
 // fallbackUpdateCouponsForWinners provides a fallback mechanism using individual updates
-// This is used when the batch operation fails
+// This is used when the batch operation fails. Uses limited concurrency to avoid
+// overwhelming the database if there are connection issues.
 func fallbackUpdateCouponsForWinners(ctx context.Context, store *db.Store, workPool chan struct{}, coupons []db.Coupons, winners []int) {
 	var wg sync.WaitGroup
+	var successCount int32
+	var failCount int32
+	var mu sync.Mutex
 
-	for i := 0; i < len(winners) && i < len(coupons); i++ {
+	numToProcess := len(winners)
+	if numToProcess > len(coupons) {
+		numToProcess = len(coupons)
+	}
+
+	for i := 0; i < numToProcess; i++ {
 		wg.Add(1)
 		go func(index int) {
 			defer wg.Done()
 			<-workPool // Get a worker from the pool
+			defer func() { workPool <- struct{}{} }() // Return the worker to the pool
 
 			userId := winners[index]
 			discount := coupons[index].Discount
@@ -262,18 +272,25 @@ func fallbackUpdateCouponsForWinners(ctx context.Context, store *db.Store, workP
 			}
 			_, err := store.Queries.UpdateCoupon(ctx, arg)
 			if err != nil {
+				mu.Lock()
+				failCount++
+				mu.Unlock()
 				if isUniqueViolationError(err) {
 					log.Printf("fallbackUpdateCouponsForWinners: user %d already has a coupon (unique constraint)", userId)
 				} else {
-					log.Printf("fallbackUpdateCouponsForWinners error: %v", err)
+					log.Printf("fallbackUpdateCouponsForWinners error for user %d: %v", userId, err)
 				}
+				return
 			}
 
-			workPool <- struct{}{} // Return the worker to the pool
+			mu.Lock()
+			successCount++
+			mu.Unlock()
 		}(i)
 	}
 
 	wg.Wait()
+	log.Printf("fallbackUpdateCouponsForWinners: completed %d/%d updates (%d failed)", successCount, numToProcess, failCount)
 }
 
 // collectUnwinners collects the user IDs of the users who did not win

--- a/db/query/coupon_reservations.sql
+++ b/db/query/coupon_reservations.sql
@@ -26,3 +26,8 @@ DELETE FROM coupon_reservations;
 
 -- name: MarkCouponReservationAsProcessed :exec
 UPDATE coupon_reservations SET is_processed = TRUE WHERE id = $1;
+
+-- name: BatchMarkCouponReservationsAsProcessed :exec
+-- Batch update coupon reservations to mark them as processed
+-- Uses ANY to efficiently update multiple rows in a single query
+UPDATE coupon_reservations SET is_processed = TRUE WHERE id = ANY($1::int[]);

--- a/db/query/coupons.sql
+++ b/db/query/coupons.sql
@@ -34,3 +34,13 @@ RETURNING *;
 -- name: DeleteCoupon :exec
 DELETE FROM coupons
 WHERE id = $1;
+
+-- name: BatchAssignCouponsToUsers :exec
+-- Batch update coupons to assign them to users
+-- Uses unnest to efficiently update multiple rows in a single query
+UPDATE coupons
+SET user_id = batch.user_id, is_used = true
+FROM (
+    SELECT unnest($1::int[]) AS coupon_id, unnest($2::int[]) AS user_id
+) AS batch
+WHERE coupons.id = batch.coupon_id AND coupons.user_id IS NULL;

--- a/db/query/coupons.sql
+++ b/db/query/coupons.sql
@@ -38,9 +38,10 @@ WHERE id = $1;
 -- name: BatchAssignCouponsToUsers :exec
 -- Batch update coupons to assign them to users
 -- Uses unnest to efficiently update multiple rows in a single query
+-- Uses int4[] for type safety with Go int32
 UPDATE coupons
 SET user_id = batch.user_id, is_used = true
 FROM (
-    SELECT unnest($1::int[]) AS coupon_id, unnest($2::int[]) AS user_id
+    SELECT unnest($1::int4[]) AS coupon_id, unnest($2::int4[]) AS user_id
 ) AS batch
 WHERE coupons.id = batch.coupon_id AND coupons.user_id IS NULL;

--- a/db/sqlc/batch_operations.go
+++ b/db/sqlc/batch_operations.go
@@ -9,6 +9,9 @@ import (
 	"github.com/lib/pq"
 )
 
+// MaxBatchSize limits the number of records per batch to prevent SQL statement overflow
+const MaxBatchSize = 1000
+
 // BatchCreateCouponsParams holds parameters for batch coupon creation
 type BatchCreateCouponsParams struct {
 	Codes      []string
@@ -17,19 +20,46 @@ type BatchCreateCouponsParams struct {
 }
 
 // BatchCreateCoupons creates multiple coupons in a single database operation
-// using a multi-row INSERT statement for better performance
+// using a multi-row INSERT statement for better performance.
+// If the batch size exceeds MaxBatchSize, it will be processed in chunks.
 func (q *Queries) BatchCreateCoupons(ctx context.Context, params BatchCreateCouponsParams) (int64, error) {
 	if len(params.Codes) == 0 {
 		return 0, nil
 	}
 
-	// Build multi-row INSERT statement
-	valueStrings := make([]string, 0, len(params.Codes))
-	valueArgs := make([]interface{}, 0, len(params.Codes)*3)
+	var totalCreated int64
 
-	for i, code := range params.Codes {
+	// Process in chunks to avoid SQL statement size limits
+	for start := 0; start < len(params.Codes); start += MaxBatchSize {
+		end := start + MaxBatchSize
+		if end > len(params.Codes) {
+			end = len(params.Codes)
+		}
+
+		chunk := params.Codes[start:end]
+		created, err := q.batchCreateCouponsChunk(ctx, chunk, params.Discount, params.ExpiryDate)
+		if err != nil {
+			return totalCreated, fmt.Errorf("batch create coupons chunk [%d:%d] failed: %w", start, end, err)
+		}
+		totalCreated += created
+	}
+
+	return totalCreated, nil
+}
+
+// batchCreateCouponsChunk creates a chunk of coupons (internal helper)
+func (q *Queries) batchCreateCouponsChunk(ctx context.Context, codes []string, discount string, expiryDate time.Time) (int64, error) {
+	if len(codes) == 0 {
+		return 0, nil
+	}
+
+	// Build multi-row INSERT statement
+	valueStrings := make([]string, 0, len(codes))
+	valueArgs := make([]interface{}, 0, len(codes)*3)
+
+	for i, code := range codes {
 		valueStrings = append(valueStrings, fmt.Sprintf("($%d, $%d, $%d)", i*3+1, i*3+2, i*3+3))
-		valueArgs = append(valueArgs, code, params.Discount, params.ExpiryDate)
+		valueArgs = append(valueArgs, code, discount, expiryDate)
 	}
 
 	query := fmt.Sprintf(
@@ -71,14 +101,15 @@ func (q *Queries) BatchAssignCouponsToUsers(ctx context.Context, params BatchAss
 	}
 
 	if len(params.CouponIDs) != len(params.UserIDs) {
-		return 0, fmt.Errorf("coupon_ids and user_ids must have the same length")
+		return 0, fmt.Errorf("coupon_ids and user_ids length mismatch: %d != %d", len(params.CouponIDs), len(params.UserIDs))
 	}
 
+	// Use int4[] (integer[]) for PostgreSQL type safety with Go int32
 	query := `
 		UPDATE coupons
 		SET user_id = batch.user_id, is_used = true
 		FROM (
-			SELECT unnest($1::int[]) AS coupon_id, unnest($2::int[]) AS user_id
+			SELECT unnest($1::int4[]) AS coupon_id, unnest($2::int4[]) AS user_id
 		) AS batch
 		WHERE coupons.id = batch.coupon_id AND coupons.user_id IS NULL
 	`

--- a/db/sqlc/batch_operations.go
+++ b/db/sqlc/batch_operations.go
@@ -1,0 +1,124 @@
+package db
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/lib/pq"
+)
+
+// BatchCreateCouponsParams holds parameters for batch coupon creation
+type BatchCreateCouponsParams struct {
+	Codes      []string
+	Discount   string
+	ExpiryDate time.Time
+}
+
+// BatchCreateCoupons creates multiple coupons in a single database operation
+// using a multi-row INSERT statement for better performance
+func (q *Queries) BatchCreateCoupons(ctx context.Context, params BatchCreateCouponsParams) (int64, error) {
+	if len(params.Codes) == 0 {
+		return 0, nil
+	}
+
+	// Build multi-row INSERT statement
+	valueStrings := make([]string, 0, len(params.Codes))
+	valueArgs := make([]interface{}, 0, len(params.Codes)*3)
+
+	for i, code := range params.Codes {
+		valueStrings = append(valueStrings, fmt.Sprintf("($%d, $%d, $%d)", i*3+1, i*3+2, i*3+3))
+		valueArgs = append(valueArgs, code, params.Discount, params.ExpiryDate)
+	}
+
+	query := fmt.Sprintf(
+		"INSERT INTO coupons (code, discount, expiry_date) VALUES %s",
+		strings.Join(valueStrings, ", "),
+	)
+
+	result, err := q.db.ExecContext(ctx, query, valueArgs...)
+	if err != nil {
+		return 0, err
+	}
+
+	return result.RowsAffected()
+}
+
+// BatchMarkCouponReservationsAsProcessed marks multiple coupon reservations as processed
+// using a single UPDATE query with ANY clause for better performance
+func (q *Queries) BatchMarkCouponReservationsAsProcessed(ctx context.Context, ids []int32) error {
+	if len(ids) == 0 {
+		return nil
+	}
+
+	query := "UPDATE coupon_reservations SET is_processed = TRUE WHERE id = ANY($1)"
+	_, err := q.db.ExecContext(ctx, query, pq.Array(ids))
+	return err
+}
+
+// BatchAssignCouponsToUsersParams holds parameters for batch coupon assignment
+type BatchAssignCouponsToUsersParams struct {
+	CouponIDs []int32
+	UserIDs   []int32
+}
+
+// BatchAssignCouponsToUsers assigns multiple coupons to users in a single database operation
+// using unnest to efficiently update multiple rows
+func (q *Queries) BatchAssignCouponsToUsers(ctx context.Context, params BatchAssignCouponsToUsersParams) (int64, error) {
+	if len(params.CouponIDs) == 0 || len(params.UserIDs) == 0 {
+		return 0, nil
+	}
+
+	if len(params.CouponIDs) != len(params.UserIDs) {
+		return 0, fmt.Errorf("coupon_ids and user_ids must have the same length")
+	}
+
+	query := `
+		UPDATE coupons
+		SET user_id = batch.user_id, is_used = true
+		FROM (
+			SELECT unnest($1::int[]) AS coupon_id, unnest($2::int[]) AS user_id
+		) AS batch
+		WHERE coupons.id = batch.coupon_id AND coupons.user_id IS NULL
+	`
+
+	result, err := q.db.ExecContext(ctx, query, pq.Array(params.CouponIDs), pq.Array(params.UserIDs))
+	if err != nil {
+		return 0, err
+	}
+
+	return result.RowsAffected()
+}
+
+// BatchCreateCouponsWithTx creates multiple coupons in a transaction for atomicity
+func (s *Store) BatchCreateCouponsWithTx(ctx context.Context, params BatchCreateCouponsParams, reservationIDs []int32) (int64, error) {
+	tx, err := s.DB.BeginTx(ctx, nil)
+	if err != nil {
+		return 0, err
+	}
+	defer tx.Rollback()
+
+	qtx := s.Queries.WithTx(tx)
+
+	// Create coupons
+	created, err := qtx.BatchCreateCoupons(ctx, params)
+	if err != nil {
+		return 0, err
+	}
+
+	// Mark reservations as processed
+	if len(reservationIDs) > 0 {
+		err = qtx.BatchMarkCouponReservationsAsProcessed(ctx, reservationIDs)
+		if err != nil {
+			return 0, err
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return 0, err
+	}
+
+	return created, nil
+}
+

--- a/db/sqlc/batch_operations.go
+++ b/db/sqlc/batch_operations.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"strings"
 	"time"
@@ -123,10 +124,11 @@ func (q *Queries) BatchAssignCouponsToUsers(ctx context.Context, params BatchAss
 }
 
 // BatchCreateCouponsWithTx creates multiple coupons in a transaction for atomicity
+// Uses ReadCommitted isolation level for balance between consistency and performance
 func (s *Store) BatchCreateCouponsWithTx(ctx context.Context, params BatchCreateCouponsParams, reservationIDs []int32) (int64, error) {
-	tx, err := s.DB.BeginTx(ctx, nil)
+	tx, err := s.DB.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelReadCommitted})
 	if err != nil {
-		return 0, err
+		return 0, fmt.Errorf("begin transaction: %w", err)
 	}
 	defer tx.Rollback()
 


### PR DESCRIPTION
## Summary
- Fix N+1 query pattern in `generateCouponsForReservations` (Issue #20) by using batch INSERT and batch UPDATE
- Fix N+1 query pattern in `updateCouponsForWinners` (Issue #21) by using batch UPDATE with unnest()
- Add fallback mechanisms for robustness if batch operations fail

## Performance Impact
- **Issue #20:** Reduces ~6000 queries to ~2 queries per 3000 reservations (estimated 10-100x improvement)
- **Issue #21:** Reduces N queries to 1 query for N winners

## Test plan
- [x] Build passes (`go build ./...`)
- [x] API tests pass (`go test ./api/...`)
- [x] `go vet` passes
- [ ] Manual testing with database

Closes #20
Closes #21