### PR TITLE
perf(db): add partial index for ListAvailableCoupons query

### DIFF
--- a/db/migration/000002_add_available_coupons_index.down.sql
+++ b/db/migration/000002_add_available_coupons_index.down.sql
@@ -1,0 +1,2 @@
+-- Drop the partial index for available coupons
+DROP INDEX IF EXISTS idx_coupons_available;

--- a/db/migration/000002_add_available_coupons_index.up.sql
+++ b/db/migration/000002_add_available_coupons_index.up.sql
@@ -1,0 +1,3 @@
+-- Create a partial index for ListAvailableCoupons query optimization
+-- This index covers: WHERE user_id IS NULL AND expiry_date >= $1 ORDER BY id
+CREATE INDEX idx_coupons_available ON coupons (expiry_date, id) WHERE user_id IS NULL;


### PR DESCRIPTION
## Summary

- Add migration 000002 to create a partial index `idx_coupons_available` on the coupons table
- Optimizes the `ListAvailableCoupons` query pattern: `WHERE user_id IS NULL AND expiry_date >= $1 ORDER BY id`
- Eliminates sequential scans for this frequently-called query during the grab window

## Details

The existing index `idx_coupons_user_id_created_at` covers `(user_id, created_at)` but not `expiry_date`. This new partial index:

```sql
CREATE INDEX idx_coupons_available ON coupons (expiry_date, id) WHERE user_id IS NULL;
```

- Covers `expiry_date` for the range condition
- Includes `id` for the `ORDER BY` clause
- Uses a partial filter on `user_id IS NULL` to keep the index small and efficient

## Test plan

- [ ] Run `make migrationup` to apply the migration
- [ ] Verify index exists: `\d coupons` in psql
- [ ] Run `EXPLAIN ANALYZE` on the ListAvailableCoupons query to confirm index usage

Closes #22