### PR TITLE
perf(db): add partial index for ListCouponReservations query

### DIFF
--- a/db/migration/000003_add_coupon_reservations_unprocessed_index.down.sql
+++ b/db/migration/000003_add_coupon_reservations_unprocessed_index.down.sql
@@ -1,0 +1,2 @@
+-- Drop the partial index for unprocessed coupon reservations
+DROP INDEX IF EXISTS idx_coupon_reservations_unprocessed;

--- a/db/migration/000003_add_coupon_reservations_unprocessed_index.up.sql
+++ b/db/migration/000003_add_coupon_reservations_unprocessed_index.up.sql
@@ -1,0 +1,4 @@
+-- Create a partial index for ListCouponReservations query optimization
+-- This index covers: WHERE is_processed = FALSE ORDER BY id
+-- Related queries: ListCouponReservations, ListCouponReservationsWithLimit
+CREATE INDEX idx_coupon_reservations_unprocessed ON coupon_reservations (id) WHERE is_processed = FALSE;


### PR DESCRIPTION
## Summary
- Add partial index `idx_coupon_reservations_unprocessed` on `coupon_reservations (id)` where `is_processed = FALSE`
- Optimizes `ListCouponReservations` and `ListCouponReservationsWithLimit` queries that run every 3 seconds during the reservation window

## Test plan
- [ ] Run `make migrateup` to apply migration
- [ ] Verify index exists: `\d coupon_reservations` in psql
- [ ] Run `EXPLAIN ANALYZE` on `ListCouponReservations` query to confirm index usage

Fixes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)