### PR TITLE
refactor(api): remove global couponTimeConfig variable

### DIFF
--- a/api/coupon_reservation.go
+++ b/api/coupon_reservation.go
@@ -17,8 +17,9 @@ type getCouponReservationRequest struct {
 	UserID int32 `uri:"user_id" binding:"required,min=1"` // Request struct for getting coupon reservation
 }
 
-// reservationListener listens for reservation requests and handles them
-func reservationListener(ctx context.Context, store *db.Store) {
+// reservationListener listens for reservation requests and handles them.
+// This is a method on Server to access timeConfig via dependency injection.
+func (s *Server) reservationListener(ctx context.Context) {
 	ticker := time.NewTicker(3 * time.Second)
 	defer ticker.Stop()
 
@@ -28,10 +29,10 @@ func reservationListener(ctx context.Context, store *db.Store) {
 			return
 		case <-ticker.C:
 			now := time.Now().Unix()
-			if now < couponTimeConfig.startReserveTime.Load() || now >= couponTimeConfig.endReserveTime.Load() {
+			if now < s.timeConfig.startReserveTime.Load() || now >= s.timeConfig.endReserveTime.Load() {
 				continue
 			}
-			handleReservations(ctx, store)
+			handleReservations(ctx, s.store)
 		}
 	}
 }

--- a/api/grab.go
+++ b/api/grab.go
@@ -175,9 +175,10 @@ func closeWorkerPool(workPool chan struct{}) {
 	close(workPool)
 }
 
-// isWithinGrabWindow checks if the current time is within the grab window
-func isWithinGrabWindow(now int64) bool {
-	return now >= couponTimeConfig.startGrabTime.Load() && now < couponTimeConfig.endGrabTime.Load()
+// isWithinGrabWindow checks if the current time is within the grab window.
+// timeConfig is passed explicitly to avoid global state (per constitution rule 3.2).
+func isWithinGrabWindow(now int64, tc *timeConfig) bool {
+	return now >= tc.startGrabTime.Load() && now < tc.endGrabTime.Load()
 }
 
 // receiveGrabRequests receives grab requests from the channel.
@@ -339,10 +340,11 @@ func collectUnwinners(reservedUsers map[int]int, winners []int) []int {
 	return unwinners
 }
 
-// handleGrabbing handles the grabbing process for the coupons
+// handleGrabbing handles the grabbing process for the coupons.
+// timeConfig is passed explicitly to avoid global state (per constitution rule 3.2).
 func handleGrabbing(ctx context.Context, store *db.Store, grabRequestChan <-chan *struct {
 	UserId int
-}, numWorkers int) {
+}, numWorkers int, tc *timeConfig) {
 
 	workPool := makeWorkerPool(numWorkers) // Create a pool of workers
 	defer closeWorkerPool(workPool)        // Close the worker pool when the function returns
@@ -359,7 +361,7 @@ func handleGrabbing(ctx context.Context, store *db.Store, grabRequestChan <-chan
 		case <-ticker.C:
 			now := time.Now().Unix()
 
-			if !isWithinGrabWindow(now) { // Check if it's within the grab time window
+			if !isWithinGrabWindow(now, tc) { // Check if it's within the grab time window
 				continue
 			}
 

--- a/api/middleware.go
+++ b/api/middleware.go
@@ -182,24 +182,26 @@ func checkUserAuthorization(ctx *gin.Context, requestedUserID int32) error {
 	return nil
 }
 
-// specialTime is a middleware function that checks if the current time falls within
-// the specified time windows for reservation and grab requests
-func specialTime(c *gin.Context) {
-	now := time.Now().Unix()
+// specialTimeMiddleware returns a middleware function that checks if the current time falls within
+// the specified time windows for reservation and grab requests.
+// This is a method on Server to access timeConfig via dependency injection.
+func (s *Server) specialTimeMiddleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		now := time.Now().Unix()
 
-	// Check if the current time is within the startReserveTime and endReserveTime range
-	if now >= couponTimeConfig.startReserveTime.Load() && now < couponTimeConfig.endReserveTime.Load() {
-		c.Next()
-		return
+		// Check if the current time is within the startReserveTime and endReserveTime range
+		if now >= s.timeConfig.startReserveTime.Load() && now < s.timeConfig.endReserveTime.Load() {
+			c.Next()
+			return
+		}
+
+		// Check if the current time is within the startGrabTime and endGrabTime range
+		if now >= s.timeConfig.startGrabTime.Load() && now < s.timeConfig.endGrabTime.Load() {
+			c.Next()
+			return
+		}
+
+		// If the current time is not within the specified time ranges, return an error
+		c.AbortWithStatusJSON(400, gin.H{"error": "not in special time"})
 	}
-
-	// Check if the current time is within the startGrabTime and endGrabTime range
-	if now >= couponTimeConfig.startGrabTime.Load() && now < couponTimeConfig.endGrabTime.Load() {
-		c.Next()
-		return
-	}
-
-	// If the current time is not within the specified time ranges, return an error
-	c.AbortWithStatusJSON(400, gin.H{"error": "not in special time"})
-	return
 }

--- a/api/server.go
+++ b/api/server.go
@@ -25,9 +25,6 @@ type timeConfig struct {
 	endGrabTime      atomic.Int64
 }
 
-// couponTimeConfig is the package-level time configuration with atomic access
-var couponTimeConfig = &timeConfig{}
-
 type Server struct {
 	store                 *db.Store
 	router                *gin.Engine
@@ -38,6 +35,7 @@ type Server struct {
 	grabRequestChan       chan *struct{ UserId int }
 	numWorkers            int
 	rateLimiter           *rateLimiter // Rate limiter for API requests
+	timeConfig            *timeConfig  // Time window configuration (injected dependency)
 }
 
 const (
@@ -72,7 +70,7 @@ func (s *Server) resetBloomFilterDaily(ctx context.Context) {
 }
 
 // couponClockTimer updates the time windows for reservation and grab requests
-func couponClockTimer(ctx context.Context) {
+func (s *Server) couponClockTimer(ctx context.Context) {
 	ticker := time.NewTicker(5 * time.Second)
 	defer ticker.Stop()
 
@@ -82,12 +80,12 @@ func couponClockTimer(ctx context.Context) {
 			return
 		case <-ticker.C:
 			startReserve := u.GetSpecificTime(ReserveStartHour, ReserveStartMin, 0).Unix()
-			couponTimeConfig.startReserveTime.Store(startReserve)
-			couponTimeConfig.endReserveTime.Store(startReserve + 5*60)
+			s.timeConfig.startReserveTime.Store(startReserve)
+			s.timeConfig.endReserveTime.Store(startReserve + 5*60)
 
 			startGrab := u.GetSpecificTime(GrabStartHour, GrabStartMin, 0).Unix()
-			couponTimeConfig.startGrabTime.Store(startGrab)
-			couponTimeConfig.endGrabTime.Store(startGrab + 60)
+			s.timeConfig.startGrabTime.Store(startGrab)
+			s.timeConfig.endGrabTime.Store(startGrab + 60)
 		}
 	}
 }
@@ -101,6 +99,7 @@ func NewServer(store *db.Store, bfr *bloom.BloomFilter, bfg *bloom.BloomFilter, 
 		grabRequestChan:       grabRC,
 		numWorkers:            numWorkers,
 		rateLimiter:           newRateLimiter(60, time.Minute), // 60 requests per minute per IP
+		timeConfig:            &timeConfig{},                   // Initialize time config (injected dependency)
 	}
 
 	router := gin.Default()
@@ -120,7 +119,7 @@ func NewServer(store *db.Store, bfr *bloom.BloomFilter, bfg *bloom.BloomFilter, 
 	}
 
 	// Time-restricted + Authenticated routes (check time window first for early rejection)
-	authenticatedTimeRestricted := router.Group("/", specialTime, authMiddleware())
+	authenticatedTimeRestricted := router.Group("/", server.specialTimeMiddleware(), authMiddleware())
 	{
 		authenticatedTimeRestricted.POST("/reserve", server.createCouponReservation)
 		authenticatedTimeRestricted.POST("/grab", server.handleGrabRequest)
@@ -206,10 +205,10 @@ func errorResponse(err error) gin.H {
 // Start starts background goroutines and the HTTP server.
 // The context is used for graceful shutdown of background tasks.
 func (s *Server) Start(ctx context.Context, address string) error {
-	go couponClockTimer(ctx)
-	go reservationListener(ctx, s.store)
+	go s.couponClockTimer(ctx)
+	go s.reservationListener(ctx)
 	go s.resetBloomFilterDaily(ctx)
-	go handleGrabbing(ctx, s.store, s.grabRequestChan, s.numWorkers)
+	go handleGrabbing(ctx, s.store, s.grabRequestChan, s.numWorkers, s.timeConfig)
 	s.rateLimiter.startCleanup(ctx)
 
 	return s.router.Run(address)


### PR DESCRIPTION
## Summary

- Remove package-level global variable `couponTimeConfig` to comply with constitution rule 3.2 (no global variables for state passing)
- Add `timeConfig` as `Server` struct member with dependency injection
- Convert functions to methods/pass `timeConfig` explicitly

## Changes

| File | Change |
|------|--------|
| `api/server.go` | Remove global `couponTimeConfig`, add `timeConfig` to `Server` struct, convert `couponClockTimer()` to method |
| `api/middleware.go` | Convert `specialTime()` to `specialTimeMiddleware()` returning closure |
| `api/coupon_reservation.go` | Convert `reservationListener()` to `Server` method |
| `api/grab.go` | Update `isWithinGrabWindow()` and `handleGrabbing()` to accept `timeConfig` parameter |

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./api/...` passes (all 13 tests)
- [ ] Manual testing of time-restricted endpoints during reservation/grab windows

Closes #41