### PR TITLE
fix(db): wrap all errors with context in batch_operations.go

### DIFF
--- a/db/sqlc/batch_operations.go
+++ b/db/sqlc/batch_operations.go
@@ -70,10 +70,15 @@ func (q *Queries) batchCreateCouponsChunk(ctx context.Context, codes []string, d
 
 	result, err := q.db.ExecContext(ctx, query, valueArgs...)
 	if err != nil {
-		return 0, err
+		return 0, fmt.Errorf("batch create coupons chunk exec: %w", err)
 	}
 
-	return result.RowsAffected()
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("batch create coupons chunk rows affected: %w", err)
+	}
+
+	return rowsAffected, nil
 }
 
 // BatchMarkCouponReservationsAsProcessed marks multiple coupon reservations as processed
@@ -85,7 +90,11 @@ func (q *Queries) BatchMarkCouponReservationsAsProcessed(ctx context.Context, id
 
 	query := "UPDATE coupon_reservations SET is_processed = TRUE WHERE id = ANY($1)"
 	_, err := q.db.ExecContext(ctx, query, pq.Array(ids))
-	return err
+	if err != nil {
+		return fmt.Errorf("batch mark reservations as processed: %w", err)
+	}
+
+	return nil
 }
 
 // BatchAssignCouponsToUsersParams holds parameters for batch coupon assignment
@@ -117,10 +126,15 @@ func (q *Queries) BatchAssignCouponsToUsers(ctx context.Context, params BatchAss
 
 	result, err := q.db.ExecContext(ctx, query, pq.Array(params.CouponIDs), pq.Array(params.UserIDs))
 	if err != nil {
-		return 0, err
+		return 0, fmt.Errorf("batch assign coupons to users: %w", err)
 	}
 
-	return result.RowsAffected()
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("batch assign coupons to users rows affected: %w", err)
+	}
+
+	return rowsAffected, nil
 }
 
 // BatchCreateCouponsWithTx creates multiple coupons in a transaction for atomicity
@@ -137,19 +151,19 @@ func (s *Store) BatchCreateCouponsWithTx(ctx context.Context, params BatchCreate
 	// Create coupons
 	created, err := qtx.BatchCreateCoupons(ctx, params)
 	if err != nil {
-		return 0, err
+		return 0, fmt.Errorf("batch create coupons: %w", err)
 	}
 
 	// Mark reservations as processed
 	if len(reservationIDs) > 0 {
 		err = qtx.BatchMarkCouponReservationsAsProcessed(ctx, reservationIDs)
 		if err != nil {
-			return 0, err
+			return 0, fmt.Errorf("mark reservations as processed: %w", err)
 		}
 	}
 
 	if err := tx.Commit(); err != nil {
-		return 0, err
+		return 0, fmt.Errorf("commit transaction: %w", err)
 	}
 
 	return created, nil


### PR DESCRIPTION
## Summary
- Wrap all bare error returns in `db/sqlc/batch_operations.go` with `fmt.Errorf("context: %w", err)` to maintain error chain traceability
- Fixes 8 unwrapped error sites across 4 functions: `batchCreateCouponsChunk`, `BatchMarkCouponReservationsAsProcessed`, `BatchAssignCouponsToUsers`, and `BatchCreateCouponsWithTx`
- Complies with project code standard section 3.1

## Context

Resolves #42 — Multiple errors in `batch_operations.go` were returned directly (`return err` / `return result.RowsAffected()`) without wrapping, making it difficult to trace error origins in production logs. This violates the project's mandatory governance standard (section 3.1) requiring all errors to be wrapped with descriptive context.

## Implementation

Each bare `return err` or implicit error return (e.g. `return result.RowsAffected()`) has been replaced with explicit error checks and `fmt.Errorf("descriptive context: %w", err)` wrapping:

| Function | Change |
|---|---|
| `batchCreateCouponsChunk` | Wrapped `ExecContext` error; extracted `RowsAffected()` to wrap its error separately |
| `BatchMarkCouponReservationsAsProcessed` | Replaced bare `return err` with wrapped error |
| `BatchAssignCouponsToUsers` | Wrapped `ExecContext` error; extracted `RowsAffected()` to wrap its error separately |
| `BatchCreateCouponsWithTx` | Wrapped 3 bare error returns: batch create, mark processed, and commit |

## Testing

- `go build ./...` — passes
- `go vet ./db/sqlc/...` — passes
- All existing error chains are preserved via `%w` verb, so `errors.Is()` / `errors.As()` continue to work correctly

## How to Verify

```bash
# 1. Check the diff
git diff develop...fix/issue-42-unwrapped-errors-batch-operations

# 2. Build
go build ./...

# 3. Vet
go vet ./db/sqlc/...

# 4. Confirm no bare error returns remain
grep -n 'return.*err$' db/sqlc/batch_operations.go
```