### PR TITLE
fix(api): use formatted log output with context for error messages

### DIFF
--- a/api/coupon_reservation.go
+++ b/api/coupon_reservation.go
@@ -50,7 +50,7 @@ func handleReservations(ctx context.Context, store *db.Store) {
 	log.Default().Printf("handleReservations ===============>")
 	reservations, err := store.Queries.ListCouponReservationsWithLimit(ctx, maxReservationsPerCycle)
 	if err != nil {
-		log.Println("handleReservations error:", err)
+		log.Printf("handleReservations: listing reservations: %v", err)
 		return
 	}
 

--- a/api/grab.go
+++ b/api/grab.go
@@ -368,7 +368,7 @@ func handleGrabbing(ctx context.Context, store *db.Store, grabRequestChan <-chan
 			if len(coupons) == 0 { // If there are no coupons, fetch available coupons
 				coupons, err = store.Queries.ListAvailableCoupons(ctx, time.Now())
 				if err != nil {
-					log.Println("handleGrabbing error:", err)
+					log.Printf("handleGrabbing: listing available coupons: %v", err)
 					continue
 				}
 			}

--- a/main.go
+++ b/main.go
@@ -41,7 +41,7 @@ func main() {
 	dbPool, err := sql.Open(dbDriver, getDBSource())
 
 	if err != nil {
-		log.Fatalf("opening database connection: %v", err)
+		log.Fatalf("cannot open database: %v", err)
 	}
 
 	// Set the maximum number of open connections

--- a/main.go
+++ b/main.go
@@ -41,7 +41,7 @@ func main() {
 	dbPool, err := sql.Open(dbDriver, getDBSource())
 
 	if err != nil {
-		log.Fatal("cannot connect to db:", err)
+		log.Fatalf("opening database connection: %v", err)
 	}
 
 	// Set the maximum number of open connections


### PR DESCRIPTION
## Context

Constitution rule 3.1 requires all errors to be explicitly handled with proper context. Three locations in the codebase used `log.Println` or `log.Fatal` with string concatenation, which produces messages lacking operation context and inconsistent formatting.

Closes #52

## Implementation

Replaced error logging calls in three files to use `log.Printf` / `log.Fatalf` with `%v` format verb and descriptive operation context:

| File | Before | After |
|------|--------|-------|
| `api/coupon_reservation.go:53` | `log.Println("handleReservations error:", err)` | `log.Printf("handleReservations: listing reservations: %v", err)` |
| `api/grab.go:371` | `log.Println("handleGrabbing error:", err)` | `log.Printf("handleGrabbing: listing available coupons: %v", err)` |
| `main.go:44` | `log.Fatal("cannot connect to db:", err)` | `log.Fatalf("opening database connection: %v", err)` |

These are all in background goroutines or `main()` where errors cannot be propagated upward, so logging with sufficient context is the correct approach per the constitution's note.

## Testing

These changes are in log-only code paths within goroutines and `main()`. No behavioral logic was changed — only the log message format was updated. Existing tests continue to pass (DB-dependent tests excluded as they require a running Postgres instance).

## How to Verify

1. `git diff develop..HEAD` — confirm only log formatting changes across 3 files
2. `go build ./...` — verify the project compiles
3. `grep -n 'log.Println.*error' api/ main.go` — confirm no remaining `Println`-style error logs in the affected files