### PR TITLE
fix(api): replace zero-value comparison with sql.ErrNoRows check in handleGrabRequest

### DIFF
--- a/api/grab.go
+++ b/api/grab.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"log"
 	"net/http"
 	"strconv"
@@ -56,13 +57,11 @@ func (s *Server) handleGrabRequest(ctx *gin.Context) {
 
 	reservation, err := s.store.Queries.GetCouponReservation(ctx, req.UserID)
 	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			ctx.JSON(http.StatusNotFound, gin.H{"error": "no reservation found"})
+			return
+		}
 		ctx.JSON(http.StatusInternalServerError, errorResponse(err))
-		return
-	}
-
-	var zeroValue db.CouponReservations
-	if reservation == zeroValue { // Check if the reservation exists
-		ctx.JSON(http.StatusNotFound, gin.H{"error": "no reservation found"})
 		return
 	}
 


### PR DESCRIPTION
## Context

Closes #56

`handleGrabRequest` in `api/grab.go` used a zero-value struct comparison to determine whether a coupon reservation exists. This approach is unreliable because:

1. If the DB query returns a valid record where all fields happen to be zero values, it would be incorrectly treated as "not found"
2. It ignores sqlc's standard error handling pattern — `GetCouponReservation` returns `sql.ErrNoRows` when no row is found

This violates **Constitution Rule 3.1** (all errors must be explicitly handled).

## Implementation

- Replaced the `var zeroValue db.CouponReservations` + struct equality check with `errors.Is(err, sql.ErrNoRows)`
- `sql.ErrNoRows` now correctly returns HTTP 404
- All other DB errors continue to return HTTP 500
- Added `"errors"` import for `errors.Is()`

## How to Verify

Review the diff in `api/grab.go:57-66` and confirm:
- `sql.ErrNoRows` is handled as a 404 (no reservation found)
- Other errors are handled as a 500 (internal server error)
- The zero-value struct comparison is fully removed