### PR TITLE
refactor(api): extract repeated anonymous struct into named GrabRequest type

### DIFF
--- a/api/grab.go
+++ b/api/grab.go
@@ -65,10 +65,8 @@ func (s *Server) handleGrabRequest(ctx *gin.Context) {
 		return
 	}
 
-	grabRequest := &struct {
-		UserId int
-	}{
-		UserId: int(reservation.UserID),
+	grabRequest := &GrabRequest{
+		UserID: int(reservation.UserID),
 	}
 
 	select {
@@ -113,9 +111,7 @@ func isWithinGrabWindow(now int64, tc *timeConfig) bool {
 // Uses context.WithTimeout for a bounded total timeout to avoid memory leaks from time.After.
 // Blocks until either: all numCoupons requests are received, or timeout (3 seconds) is reached.
 // This ensures we give pending requests time to arrive while preventing indefinite blocking.
-func receiveGrabRequests(grabRequestChan <-chan *struct {
-	UserId int
-}, numCoupons int) map[int]int {
+func receiveGrabRequests(grabRequestChan <-chan *GrabRequest, numCoupons int) map[int]int {
 	reservedUsers := make(map[int]int)
 
 	// Total timeout of 3 seconds - prevents indefinite blocking while giving requests time to arrive
@@ -125,7 +121,7 @@ func receiveGrabRequests(grabRequestChan <-chan *struct {
 	for i := 0; i < numCoupons; i++ {
 		select {
 		case grabRequest := <-grabRequestChan:
-			reservedUsers[grabRequest.UserId]++
+			reservedUsers[grabRequest.UserID]++
 		case <-ctx.Done():
 			log.Default().Printf("timeout waiting for grab requests, received %d/%d requests from %d unique users",
 				i, numCoupons, len(reservedUsers))
@@ -270,9 +266,7 @@ func collectUnwinners(reservedUsers map[int]int, winners []int) []int {
 
 // handleGrabbing handles the grabbing process for the coupons.
 // timeConfig is passed explicitly to avoid global state (per constitution rule 3.2).
-func handleGrabbing(ctx context.Context, store *db.Store, grabRequestChan <-chan *struct {
-	UserId int
-}, numWorkers int, tc *timeConfig) {
+func handleGrabbing(ctx context.Context, store *db.Store, grabRequestChan <-chan *GrabRequest, numWorkers int, tc *timeConfig) {
 
 	workPool := makeWorkerPool(numWorkers) // Create a pool of workers
 	defer closeWorkerPool(workPool)        // Close the worker pool when the function returns

--- a/api/server.go
+++ b/api/server.go
@@ -25,6 +25,11 @@ type timeConfig struct {
 	endGrabTime      atomic.Int64
 }
 
+// GrabRequest represents a user's grab request.
+type GrabRequest struct {
+	UserID int
+}
+
 type Server struct {
 	store                 *db.Store
 	router                *gin.Engine
@@ -32,7 +37,7 @@ type Server struct {
 	bloomFilterForReserve *bloom.BloomFilter // Bloom filter for reservation requests
 	grabBloomMu           sync.RWMutex       // RWMutex to protect bloomFilterForGrab operations
 	reserveBloomMu        sync.RWMutex       // RWMutex to protect bloomFilterForReserve operations
-	grabRequestChan       chan *struct{ UserId int }
+	grabRequestChan       chan *GrabRequest
 	numWorkers            int
 	rateLimiter           *rateLimiter // Rate limiter for API requests
 	timeConfig            *timeConfig  // Time window configuration (injected dependency)
@@ -91,7 +96,7 @@ func (s *Server) couponClockTimer(ctx context.Context) {
 }
 
 // NewServer creates a new server instance
-func NewServer(store *db.Store, bfr *bloom.BloomFilter, bfg *bloom.BloomFilter, grabRC chan *struct{ UserId int }, numWorkers int) *Server {
+func NewServer(store *db.Store, bfr *bloom.BloomFilter, bfg *bloom.BloomFilter, grabRC chan *GrabRequest, numWorkers int) *Server {
 	server := &Server{
 		store:                 store,
 		bloomFilterForReserve: bfr,

--- a/main.go
+++ b/main.go
@@ -35,7 +35,7 @@ func main() {
 	grabBloomFilter := bloom.NewWithEstimates(1000000, 0.001)
 
 	// Initialize channel for grab requests
-	grabRequestChan := make(chan *struct{ UserId int }, maxConcurrentRequests)
+	grabRequestChan := make(chan *api.GrabRequest, maxConcurrentRequests)
 
 	// Open a connection to the database
 	dbPool, err := sql.Open(dbDriver, getDBSource())


### PR DESCRIPTION
## 背景 (Context)

Closes #57

匿名结构体 `*struct{ UserId int }` 在代码库中 4 处重复定义（`main.go`、`api/server.go`、`api/grab.go` x2），带来以下问题：

- **维护负担**：修改字段需要同步更新多处
- **命名规范违反**：`UserId` 不符合 Go 的缩写命名惯例（应为 `UserID`）
- **可读性差**：匿名结构体在函数签名中难以阅读，尤其是跨多行的 channel 类型

## 实现方案 (Implementation)

在 `api/server.go` 中定义命名类型：

\`\`\`go
// GrabRequest represents a user's grab request.
type GrabRequest struct {
    UserID int
}
\`\`\`

然后将所有 4 处匿名结构体替换为 \`*GrabRequest\`：

| 文件 | 变更 |
|------|------|
| \`api/server.go\` | 新增 \`GrabRequest\` 类型；更新 \`Server.grabRequestChan\` 字段类型和 \`NewServer\` 参数类型 |
| \`api/grab.go\` | 更新 \`handleGrabRequest\`、\`receiveGrabRequests\`、\`handleGrabbing\` 的类型引用；\`UserId\` → \`UserID\` |
| \`main.go\` | channel 初始化改用 \`chan *api.GrabRequest\` |

这是纯重构，不改变任何运行时行为。

## 测试 (Testing)

- 项目通过 \`go build ./...\` 编译成功，无任何类型错误
- 现有单元测试全部通过（仅数据库相关测试因无本地 DB 连接而跳过，与本次变更无关）

## 如何手动验证 (How to Verify)

\`\`\`bash
# 1. 切换到分支
git checkout fix/issue-57-extract-grab-request-type

# 2. 确认编译通过
go build ./...

# 3. 运行测试
go test ./...

# 4. 确认不再有匿名结构体引用
grep -rn 'struct{.*UserId' api/ main.go
# 应无任何输出

# 5. 确认新类型已定义
grep -n 'type GrabRequest' api/server.go
# 应输出类型定义
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)