### PR TITLE
fix(util): replace panic with error return in secureRandomInt (#58)

### DIFF
--- a/db/sqlc/users_test.go
+++ b/db/sqlc/users_test.go
@@ -8,14 +8,17 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func generateUserInfo() (string, string) {
-	name := u.RandomName()
-	domain := u.RandomDomain()
+func generateUserInfo(t *testing.T) (string, string) {
+	t.Helper()
+	name, err := u.RandomName()
+	require.NoError(t, err)
+	domain, err := u.RandomDomain()
+	require.NoError(t, err)
 	return name, name + domain
 }
 
 func TestCreateUser(t *testing.T) {
-	name, email := generateUserInfo()
+	name, email := generateUserInfo(t)
 	arg := CreateUserParams{
 		Username: name,
 		Email:   email,
@@ -29,7 +32,7 @@ func TestCreateUser(t *testing.T) {
 }
 
 func TestGetUser(t *testing.T) {
-	name, email := generateUserInfo()
+	name, email := generateUserInfo(t)
 	arg := CreateUserParams{
 		Username: name,
 		Email:   email,
@@ -47,7 +50,7 @@ func TestGetUser(t *testing.T) {
 }
 
 func TestUpdateUser(t *testing.T) {
-	name, email := generateUserInfo()
+	name, email := generateUserInfo(t)
 	arg := CreateUserParams{
 		Username: name,
 		Email:   email,
@@ -56,9 +59,11 @@ func TestUpdateUser(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, user)
 
+	newName, err := u.RandomName()
+	require.NoError(t, err)
 	arg2 := UpdateUserParams{
 		ID: user.ID,
-		Username: u.RandomName(),
+		Username: newName,
 		Email: email,
 	}
 	user2, err := testQueries.UpdateUser(context.Background(), arg2)
@@ -70,7 +75,7 @@ func TestUpdateUser(t *testing.T) {
 }
 
 func TestDeleteUser(t *testing.T) {
-	name, email := generateUserInfo()
+	name, email := generateUserInfo(t)
 	arg := CreateUserParams{
 		Username: name,
 		Email:    email,

--- a/util/random.go
+++ b/util/random.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"crypto/rand"
+	"fmt"
 	"math/big"
 	"strings"
 )
@@ -9,47 +10,51 @@ import (
 const alphabet = "abcdefghijklmnopqrstuvwxyz"
 
 // secureRandomInt generates a cryptographically secure random integer in [0, max)
-func secureRandomInt(max int) int {
+func secureRandomInt(max int) (int, error) {
 	if max <= 0 {
-		return 0
+		return 0, nil
 	}
 	n, err := rand.Int(rand.Reader, big.NewInt(int64(max)))
 	if err != nil {
-		// Fallback: this should never happen in normal circumstances
-		// as crypto/rand.Reader is always available on supported platforms
-		panic("crypto/rand failed: " + err.Error())
+		return 0, fmt.Errorf("generating secure random int: %w", err)
 	}
-	return int(n.Int64())
+	return int(n.Int64()), nil
 }
 
 // RandomDomain returns a random email domain for testing purposes
-func RandomDomain() string {
-	var sb strings.Builder
-
-	// Append domain name
+func RandomDomain() (string, error) {
 	domain := []string{"gmail.com", "yahoo.com", "hotmail.com", "outlook.com"}
-	sb.WriteString("@")
-	sb.WriteString(domain[secureRandomInt(len(domain))])
-
-	return sb.String()
+	idx, err := secureRandomInt(len(domain))
+	if err != nil {
+		return "", fmt.Errorf("generating random domain: %w", err)
+	}
+	return "@" + domain[idx], nil
 }
 
 // RandomName generates a random username for testing purposes
-func RandomName() string {
+func RandomName() (string, error) {
 	var sb strings.Builder
 	k := len(alphabet)
 
 	// Generate random username
-	usernameLength := secureRandomInt(10) + 5 // Random length between 5 and 14
+	usernameLength, err := secureRandomInt(10)
+	if err != nil {
+		return "", fmt.Errorf("generating random name length: %w", err)
+	}
+	usernameLength += 5 // Random length between 5 and 14
+
 	for i := 0; i < usernameLength; i++ {
-		c := alphabet[secureRandomInt(k)]
-		sb.WriteByte(c)
+		idx, err := secureRandomInt(k)
+		if err != nil {
+			return "", fmt.Errorf("generating random name character: %w", err)
+		}
+		sb.WriteByte(alphabet[idx])
 	}
 
-	return sb.String()
+	return sb.String(), nil
 }
 
 // RandomNumber generates a cryptographically secure random number in [0, 10)
-func RandomNumber() int {
+func RandomNumber() (int, error) {
 	return secureRandomInt(10)
 }

--- a/util/random.go
+++ b/util/random.go
@@ -12,7 +12,7 @@ const alphabet = "abcdefghijklmnopqrstuvwxyz"
 // secureRandomInt generates a cryptographically secure random integer in [0, max)
 func secureRandomInt(max int) (int, error) {
 	if max <= 0 {
-		return 0, nil
+		return 0, fmt.Errorf("max must be positive, got %d", max)
 	}
 	n, err := rand.Int(rand.Reader, big.NewInt(int64(max)))
 	if err != nil {
@@ -46,7 +46,7 @@ func RandomName() (string, error) {
 	for i := 0; i < usernameLength; i++ {
 		idx, err := secureRandomInt(k)
 		if err != nil {
-			return "", fmt.Errorf("generating random name character: %w", err)
+			return "", fmt.Errorf("generating random name character at index %d: %w", i, err)
 		}
 		sb.WriteByte(alphabet[idx])
 	}
@@ -56,5 +56,9 @@ func RandomName() (string, error) {
 
 // RandomNumber generates a cryptographically secure random number in [0, 10)
 func RandomNumber() (int, error) {
-	return secureRandomInt(10)
+	n, err := secureRandomInt(10)
+	if err != nil {
+		return 0, fmt.Errorf("generating random number: %w", err)
+	}
+	return n, nil
 }


### PR DESCRIPTION
## 背景 (Context)

修复 Issue #58：`util/random.go` 中 `secureRandomInt` 在 `crypto/rand` 失败时使用 `panic`，违反了项目宪法 3.1「所有错误都必须被显式处理」的原则。

## 实现方案 (Implementation)

- 将 `secureRandomInt(max int) int` 改为 `secureRandomInt(max int) (int, error)`，用 `fmt.Errorf` 包装错误替代 `panic`
- 公开函数 `RandomDomain()`、`RandomName()`、`RandomNumber()` 同步改为返回 `(T, error)` 签名
- 更新 `db/sqlc/users_test.go` 中所有调用方，使用 `require.NoError` 显式处理错误

## 测试 (Testing)

- 更新了 `generateUserInfo` 辅助函数，接受 `*testing.T` 参数并使用 `t.Helper()` 标记
- 所有四个测试函数（`TestCreateUser`、`TestGetUser`、`TestUpdateUser`、`TestDeleteUser`）已适配新签名
- 通过 `go vet ./util/... ./db/sqlc/...` 验证无编译错误

## 如何手动验证 (How to Verify)

```bash
# 1. 切换到功能分支
git checkout fix/issue-58-replace-panic-with-error-return

# 2. 验证编译通过
go build ./...

# 3. 运行受影响的测试
go test ./util/... ./db/sqlc/...

# 4. 确认 secureRandomInt 不再包含 panic
grep -n "panic" util/random.go  # 应无输出
```

Closes #58