### PR TITLE
fix(util): call time.Now() once to avoid cross-boundary inconsistency (#59)

### DIFF
--- a/util/time.go
+++ b/util/time.go
@@ -3,6 +3,6 @@ package util
 import "time"
 
 func GetSpecificTime(hour, minute, second int) time.Time {
-	specificTime := time.Date(time.Now().Year(), time.Now().Month(), time.Now().Day(), hour, minute, second, 0, time.UTC)
-	return specificTime
+	now := time.Now()
+	return time.Date(now.Year(), now.Month(), now.Day(), hour, minute, second, 0, time.UTC)
 }


### PR DESCRIPTION
## Background

Closes #59

`GetSpecificTime()` in `util/time.go` called `time.Now()` three times within a single expression to extract `Year()`, `Month()`, and `Day()`. In rare edge cases (e.g., calling at `2024-12-31 23:59:59.999`), the three calls could return different dates, leading to an inconsistent `time.Date` result.

## Implementation

Store the result of a single `time.Now()` call in a local variable `now`, then use `now.Year()`, `now.Month()`, and `now.Day()` to construct the date. This guarantees year, month, and day are always from the same snapshot.

## Testing

This is a minimal, low-risk change. The function's behavior is unchanged under normal conditions — only the cross-boundary edge case is fixed.

## How to Verify

```bash
# Build to confirm compilation
go build ./util/...

# Review the diff — only util/time.go is changed
git diff develop..fix/issue-59-time-now-cross-boundary
```