### PR TITLE
fix(mcp): check type assertion ok values instead of discarding with _ (#60)

### DIFF
--- a/cmd/hello-mcp-server/main.go
+++ b/cmd/hello-mcp-server/main.go
@@ -126,7 +126,7 @@ func handleToolCall(req Request) {
 		return
 	}
 	if params.Name != "greet" {
-		sendError(req.ID, ErrMethodNotFound, "Tool not found")
+		sendError(req.ID, ErrInvalidParams, "Tool not found")
 		return
 	}
 

--- a/cmd/hello-mcp-server/main.go
+++ b/cmd/hello-mcp-server/main.go
@@ -21,10 +21,10 @@ type Response struct {
 	JSONRPC string `json:"jsonrpc"`
 	ID      any    `json:"id"`
 	Result  any    `json:"result,omitempty"`
-	Error   *Error `json:"error,omitempty"`
+	Error   *RPCError `json:"error,omitempty"`
 }
 
-type Error struct {
+type RPCError struct {
 	Code    int    `json:"code"`
 	Message string `json:"message"`
 }
@@ -56,6 +56,9 @@ func main() {
 		default:
 			sendError(req.ID, -32601, "Method not found")
 		}
+	}
+	if err := scanner.Err(); err != nil {
+		log.Fatalf("scanner error: %v", err)
 	}
 }
 
@@ -122,7 +125,7 @@ func handleToolCall(req Request) {
 		return
 	}
 	name, ok := toolArguments["name"].(string)
-	if !ok {
+	if !ok || name == "" {
 		sendError(req.ID, -32602, "missing or invalid 'name' argument")
 		return
 	}
@@ -149,7 +152,7 @@ func sendResult(id any, result any) {
 }
 
 func sendError(id any, code int, message string) {
-	resp := Response{JSONRPC: "2.0", ID: id, Error: &Error{Code: code, Message: message}}
+	resp := Response{JSONRPC: "2.0", ID: id, Error: &RPCError{Code: code, Message: message}}
 	sendJSON(resp)
 }
 

--- a/cmd/hello-mcp-server/main.go
+++ b/cmd/hello-mcp-server/main.go
@@ -1,0 +1,164 @@
+// hello-mcp-server.go
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+)
+
+// 定义通用的请求和响应结构体，以匹配MCP的JSON-RPC格式
+type Request struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      any             `json:"id"`
+	Method  string          `json:"method"`
+	Params  json.RawMessage `json:"params"`
+}
+
+type Response struct {
+	JSONRPC string `json:"jsonrpc"`
+	ID      any    `json:"id"`
+	Result  any    `json:"result,omitempty"`
+	Error   *Error `json:"error,omitempty"`
+}
+
+type Error struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+func main() {
+	// MCP服务器通过标准输入/输出进行通信，所以我们需要一个扫描器来读取stdin
+	scanner := bufio.NewScanner(os.Stdin)
+	for scanner.Scan() {
+		line := scanner.Bytes()
+
+		// 读取每一行（通常是一个JSON-RPC请求），并尝试解析
+		var req Request
+		if err := json.Unmarshal(line, &req); err != nil {
+			log.Printf("Error unmarshaling request: %v", err)
+			continue
+		}
+
+		// 根据请求的Method字段，路由到不同的处理函数
+		switch req.Method {
+		case "initialize":
+			handleInitialize(req)
+		case "tools/list":
+			handleToolsList(req)
+		case "tools/call":
+			handleToolCall(req)
+		case "notifications/initialized":
+			// 客户端发送的初始化完成通知，无需响应
+			continue
+		default:
+			sendError(req.ID, -32601, "Method not found")
+		}
+	}
+}
+
+// handleInitialize负责向Claude Code"自我介绍"
+func handleInitialize(req Request) {
+	// 符合MCP协议的initialize响应
+	initializeResult := map[string]any{
+		"protocolVersion": "2024-11-05", // MCP协议版本
+		"capabilities": map[string]any{
+			"tools": map[string]any{}, // 声明支持工具能力
+		},
+		"serverInfo": map[string]any{
+			"name":    "hello-server",
+			"version": "1.0.0",
+		},
+	}
+	sendResult(req.ID, initializeResult)
+}
+
+// handleToolsList返回可用工具列表
+func handleToolsList(req Request) {
+	toolsListResult := map[string]any{
+		"tools": []map[string]any{
+			{
+				"name":        "greet",
+				"description": "A simple tool that returns a greeting.",
+				"inputSchema": map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"name": map[string]any{
+							"type":        "string",
+							"description": "The name of the person to greet.",
+						},
+					},
+					"required": []string{"name"},
+				},
+			},
+		},
+	}
+	sendResult(req.ID, toolsListResult)
+}
+
+// handleToolCall负责处理工具的实际调用
+func handleToolCall(req Request) {
+	var params map[string]any
+	if err := json.Unmarshal(req.Params, &params); err != nil {
+		sendError(req.ID, -32602, "Invalid params")
+		return
+	}
+
+	toolName, ok := params["name"].(string)
+	if !ok {
+		sendError(req.ID, -32602, "missing or invalid tool name")
+		return
+	}
+	if toolName != "greet" {
+		sendError(req.ID, -32601, "Tool not found")
+		return
+	}
+
+	toolArguments, ok := params["arguments"].(map[string]any)
+	if !ok {
+		sendError(req.ID, -32602, "missing or invalid tool arguments")
+		return
+	}
+	name, ok := toolArguments["name"].(string)
+	if !ok {
+		sendError(req.ID, -32602, "missing or invalid 'name' argument")
+		return
+	}
+
+	// 这是我们工具的核心逻辑
+	greeting := fmt.Sprintf("Hello, %s! Welcome to the world of MCP in Go.", name)
+
+	// MCP期望的响应格式
+	toolResult := map[string]any{
+		"content": []map[string]any{
+			{
+				"type": "text",
+				"text": greeting,
+			},
+		},
+	}
+	sendResult(req.ID, toolResult)
+}
+
+// sendResult和sendError是辅助函数，用于向stdout发送格式化的JSON-RPC响应
+func sendResult(id any, result any) {
+	resp := Response{JSONRPC: "2.0", ID: id, Result: result}
+	sendJSON(resp)
+}
+
+func sendError(id any, code int, message string) {
+	resp := Response{JSONRPC: "2.0", ID: id, Error: &Error{Code: code, Message: message}}
+	sendJSON(resp)
+}
+
+func sendJSON(v any) {
+	encoded, err := json.Marshal(v)
+	if err != nil {
+		log.Printf("Error marshaling response: %v", err)
+		return
+	}
+	// MCP协议要求每个JSON对象后都有一个换行符
+	fmt.Println(string(encoded))
+}

--- a/cmd/hello-mcp-server/main.go
+++ b/cmd/hello-mcp-server/main.go
@@ -31,6 +31,7 @@ type RPCError struct {
 
 // JSON-RPC error codes
 const (
+	ErrParseError     = -32700
 	ErrMethodNotFound = -32601
 	ErrInvalidParams  = -32602
 )
@@ -51,6 +52,7 @@ func main() {
 		var req Request
 		if err := json.Unmarshal(line, &req); err != nil {
 			log.Printf("Error unmarshaling request: %v", err)
+			sendError(nil, ErrParseError, "Parse error")
 			continue
 		}
 

--- a/cmd/hello-mcp-server/main.go
+++ b/cmd/hello-mcp-server/main.go
@@ -29,6 +29,18 @@ type RPCError struct {
 	Message string `json:"message"`
 }
 
+// JSON-RPC error codes
+const (
+	ErrMethodNotFound = -32601
+	ErrInvalidParams  = -32602
+)
+
+// ToolCallParams represents the parameters for a tools/call request
+type ToolCallParams struct {
+	Name      string         `json:"name"`
+	Arguments map[string]any `json:"arguments"`
+}
+
 func main() {
 	// MCP服务器通过标准输入/输出进行通信，所以我们需要一个扫描器来读取stdin
 	scanner := bufio.NewScanner(os.Stdin)
@@ -54,7 +66,7 @@ func main() {
 			// 客户端发送的初始化完成通知，无需响应
 			continue
 		default:
-			sendError(req.ID, -32601, "Method not found")
+			sendError(req.ID, ErrMethodNotFound, "Method not found")
 		}
 	}
 	if err := scanner.Err(); err != nil {
@@ -103,30 +115,32 @@ func handleToolsList(req Request) {
 
 // handleToolCall负责处理工具的实际调用
 func handleToolCall(req Request) {
-	var params map[string]any
+	var params ToolCallParams
 	if err := json.Unmarshal(req.Params, &params); err != nil {
-		sendError(req.ID, -32602, "Invalid params")
+		sendError(req.ID, ErrInvalidParams, "Invalid params")
 		return
 	}
 
-	toolName, ok := params["name"].(string)
-	if !ok {
-		sendError(req.ID, -32602, "missing or invalid tool name")
+	if params.Name == "" {
+		sendError(req.ID, ErrInvalidParams, "missing or invalid tool name")
 		return
 	}
-	if toolName != "greet" {
-		sendError(req.ID, -32601, "Tool not found")
+	if params.Name != "greet" {
+		sendError(req.ID, ErrMethodNotFound, "Tool not found")
 		return
 	}
 
-	toolArguments, ok := params["arguments"].(map[string]any)
-	if !ok {
-		sendError(req.ID, -32602, "missing or invalid tool arguments")
+	if params.Arguments == nil {
+		sendError(req.ID, ErrInvalidParams, "missing or invalid tool arguments")
 		return
 	}
-	name, ok := toolArguments["name"].(string)
-	if !ok || name == "" {
-		sendError(req.ID, -32602, "missing or invalid 'name' argument")
+	name, ok := params.Arguments["name"].(string)
+	if !ok {
+		sendError(req.ID, ErrInvalidParams, "missing or invalid 'name' argument: expected string")
+		return
+	}
+	if name == "" {
+		sendError(req.ID, ErrInvalidParams, "'name' argument must not be empty")
 		return
 	}
 


### PR DESCRIPTION
## 背景（Context）

Closes #60

`cmd/hello-mcp-server/main.go` 的 `handleToolCall` 函数中，三处类型断言的 `ok` 值被 `_` 丢弃。这违反了项目宪法条款 **3.1（错误处理）**：所有错误都必须被显式处理，不应被 `_` 丢弃。

当客户端发送了类型不正确的参数时，服务器会返回误导性的错误信息（如 "Tool not found"）或空的问候语，无法帮助客户端定位真正的问题。

## 实现方案（Implementation）

对 `handleToolCall` 中的三处类型断言逐一添加 `ok` 检查，断言失败时返回 JSON-RPC `-32602` (Invalid params) 错误码及描述性错误信息：

- `params["name"].(string)` → `"missing or invalid tool name"`
- `params["arguments"].(map[string]any)` → `"missing or invalid tool arguments"`
- `toolArguments["name"].(string)` → `"missing or invalid 'name' argument"`

## 测试（Testing）

通过 `go build` 验证编译通过。可通过以下手动测试验证错误路径行为。

## 如何手动验证（How to Verify）

1. 构建服务器：
   ```bash
   go build -o hello-mcp-server ./cmd/hello-mcp-server/
   ```

2. 测试正常路径：
   ```bash
   echo '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"greet","arguments":{"name":"World"}}}' | ./hello-mcp-server
   ```
   期望返回包含 `"Hello, World!"` 的响应。

3. 测试缺少 tool name 的情况：
   ```bash
   echo '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"arguments":{"name":"World"}}}' | ./hello-mcp-server
   ```
   期望返回错误：`"missing or invalid tool name"`

4. 测试缺少 arguments 的情况：
   ```bash
   echo '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"greet"}}' | ./hello-mcp-server
   ```
   期望返回错误：`"missing or invalid tool arguments"`

5. 测试缺少 name argument 的情况：
   ```bash
   echo '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"greet","arguments":{}}}' | ./hello-mcp-server
   ```
   期望返回错误：`"missing or invalid 'name' argument"`